### PR TITLE
Refactor auth/env loading + improve Makefile with kafka-init

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -1,28 +1,30 @@
-.PHONY: kafka-init kafka-list kafka-events kafka-snapshot
+.PHONY: kafka-init kafka-list kafka-events kafka-snapshot run demo
 
-# Creează topicurile necesare
+# Create required Kafka topics (only once per setup)
 kafka-init:
-	docker exec -it kafka kafka-topics --create --topic spotify_recent_events --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1 || true
-	docker exec -it kafka kafka-topics --create --topic spotify_recent_snapshot --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1 || true
+	docker exec -it kafka kafka-topics --create --if-not-exists --topic spotify_recent_events --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+	docker exec -it kafka kafka-topics --create --if-not-exists --topic spotify_recent_snapshot --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+	docker exec -it kafka kafka-topics --list --bootstrap-server localhost:9092
 
-# Listează toate topicurile existente
+# List all existing Kafka topics
 kafka-list:
 	docker exec -it kafka kafka-topics --list --bootstrap-server localhost:9092
 
-# Consumă ultimele mesaje din topicul "spotify_recent_events"
+# Consume all messages from the "spotify_recent_events" topic
 kafka-events:
 	kcat -b localhost:9092 -t spotify_recent_events -C -o beginning -q
 
-# Consumă ultimul snapshot
+# Consume all messages from the "spotify_recent_snapshot" topic
 kafka-snapshot:
 	kcat -b localhost:9092 -t spotify_recent_snapshot -C -o beginning -q
-run:
+
+# Run the main ingestion script (will also ensure topics exist)
+run: kafka-init
 	.venv/bin/python3 DE-Spotify.py
-	
-demo:
-	@echo ">>> Ctrl+C ca să oprești fiecare consumator"
+
+# Demo mode: start both consumers in parallel
+run-consumers:
+	@echo ">>> Press Ctrl+C to stop each consumer"
 	$(MAKE) -s kafka-events & \
 	$(MAKE) -s kafka-snapshot
-
-
 


### PR DESCRIPTION
Hey zusammen,
ich habe meinen Code an die von Alexander vorgeschlagene Struktur angepasst und soeben einen Pull Request erstellt.

Aktuell funktioniert der Kafka Consumer, den wir alle drei verwenden können – jeder von uns muss sich nur eigene Topics erstellen, abhängig von den jeweiligen User Stories.

Meine Topics sind:

spotify_recent_events → für die Event-Streaming User Story

spotify_recent_snapshot → für die Snapshot/State User Story

Außerdem läuft auch die .env-Konfiguration und die OAuth-Authentifizierung. Jeder von uns muss sich also eine eigene .env-Datei anlegen und dort seine persönlichen Spotify-Credentials (CLIENT_ID, CLIENT_SECRET, USERNAME, REDIRECT_URI) eintragen, damit der Login funktioniert.

Damit könnt ihr dann eure eigenen User Stories sauber anbinden