### PR TITLE
Refactor MongoDB + Mongo Express: switched to named volume, unified container name, cleaner mongo-express config

### DIFF
--- a/src/docker-compose.yml.mongo
+++ b/src/docker-compose.yml.mongo
@@ -1,7 +1,7 @@
 services:
   mongo:
     image: mongo:6.0
-    container_name: mongodb
+    container_name: mongo
     restart: always
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
@@ -9,7 +9,7 @@ services:
     ports:
       - "27017:27017"
     volumes:
-      - ./mongo_data:/data/db
+      - mongo_data:/data/db
 
   mongo-express:
     image: mongo-express:latest
@@ -18,11 +18,7 @@ services:
     depends_on:
       - mongo
     environment:
-      ME_CONFIG_MONGODB_ADMINUSERNAME: root
-      ME_CONFIG_MONGODB_ADMINPASSWORD: example
-      ME_CONFIG_MONGODB_SERVER: mongo
-      
-      #Basic Auth for the web UI
+      ME_CONFIG_MONGODB_URL: "mongodb://root:example@mongo:27017/?authSource=admin"
       ME_CONFIG_BASICAUTH_USERNAME: admin
       ME_CONFIG_BASICAUTH_PASSWORD: secret
     ports:
@@ -30,3 +26,4 @@ services:
 
 volumes:
   mongo_data:
+


### PR DESCRIPTION
- Switched from bind mount (./mongo_data) to named volume (mongo_data) → avoids polluting the repo and prevents permission issues across OS.
- Unified container name to 'mongo' for consistency with mongo-express default connection string.
- Updated mongo-express config to use ME_CONFIG_MONGODB_URL → cleaner, single connection string instead of separate env vars.
- Kept basic auth for the web UI to restrict access.