### PR TITLE
Add Streamlit dashboard and team setup guide:

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,75 +1,120 @@
-# Project Status – Data Engineering Spotify
+# Project Status — Spotify Data Engineering (as of 28‑Sep‑2025)
 
-## ✅ Current Progress
-
-### Data Ingestion
-- Data is successfully ingested from the **Spotify API**:
-  - Retrieve **tracklist of an album** (title + duration).
-  - Retrieve **top tracks of an artist**.
-  - Retrieve **recently played tracks** and push events into **Kafka**.
-- **Infrastructure (Kafka/Zookeeper/MongoDB)**:
-  - `docker-compose.yml` spins up Kafka, Zookeeper, and MongoDB.
-  - `makefile` initializes and lists topics (`spotify_recent_events`, `spotify_recent_snapshot`) and provides `consume` target.
-  - Kafka ingestion tested: events visible via `kcat`.
-  - MongoDB consumer added: events/snapshots are persisted into MongoDB (`kafka_consumer.py`).
-- **Documentation**:
-  - `run-and-start.md` explains setup for `.env`, Docker, and Makefile usage.
-  - `STATUS.md` updated with today’s progress.
-
-## Implemented User Stories (so far, from Dorin)
-
-1. **As a user, I want to see the tracklist of an album with titles and duration, so I can decide which songs to listen to first.**  
-   - Implemented by fetching full album tracklists from the Spotify API.  
-   - The system prints **each song title and its duration** for the albums detected in the user’s listening history.  
-   - Albums are identified automatically from the **last 50 tracks played**.  
-   - Each album is displayed with:  
-     - Album title and release date.  
-     - Complete list of songs (title + duration).  
-     - Total runtime of the album.  
-
-2. **As a music fan, I want to fetch the top tracks of an artist, so I can quickly get an overview of their most popular songs.**  
-   - Implemented via the Spotify API endpoint for an artist’s top tracks.  
-   - The system automatically selects the **dominant artist** (most frequently played) from the user’s recent history.  
-   - Then it retrieves and prints the **Top 10 tracks** of that artist, including title and duration.  
-   - The **market parameter** ensures the list is relevant for the user’s country.  
-
-3. **As a data engineer, I want to persist streaming data into MongoDB, so I can query and analyze later.**  
-   - Implemented by adding `kafka_consumer.py`, which consumes from Kafka and inserts into MongoDB.  
-   - Each insert is logged with a **UTC timestamp** using `datetime.now(timezone.utc)`.  
-   - Verified end-to-end: Spotify API → Kafka → MongoDB.
+This file summarizes the **current state of the repo**, what works end‑to‑end, what changed recently, and what we plan next. It reflects the code you have in `main`/`avd-branch` today (Kafka + Mongo ingestion working, plus the Streamlit dashboard).
 
 ---
 
-⚠️ **Note:** At this point, only Dorin’s user stories have been implemented. Other team members will add their own stories in the next iteration.
+## What works end‑to‑end (mine = Dorin’s part, prefix `avd_`)
+
+### 1) Ingestion from Spotify → Kafka
+- The producer pulls **recently played tracks** using the Spotify API and builds one **event per play**.
+- Events are published to Kafka topic: **`avd_spotify_recent_events`**.
+- Event schema (simplified):
+  ```json
+  {
+    "event_version": "1.0",
+    "event_type": "recent_play",
+    "generated_at": "...",
+    "user_id": "...",
+    "country": "AT",
+    "market_used": "DE",
+    "played_at": "2025-09-22T07:58:49.561Z",
+    "track_id": "...",
+    "track_name": "...",
+    "track_duration_ms": 123456,
+    "album_id": "...",
+    "album_name": "...",
+    "album_release_date": "...",
+    "artist_ids": ["..."],
+    "artist_names": ["..."]
+  }
+  ```
+
+### 2) Kafka → MongoDB consumer (idempotent writes)
+- Topic **`avd_spotify_recent_events`** → collection **`avd_recent_events`** (append‑only).
+- Unique index: **`(user_id, track_id, played_at)`** ensures **no duplicates** when re‑processing.
+- Topic **`avd_artist_market_top_tracks`** → collection **`avd_artist_market_top_tracks`** (snapshot per `(user_id, artist_id, market)`).
+- Upsert key for snapshots: **`(user_id, artist_id, market)`**, keeping only the latest document for that triplet.
+
+### 3) Dominant artist & Top‑10 by market (my second user story)
+- The producer computes the **dominant artist** from the last 50 plays, then fetches **Top‑10** tracks for a selected market and publishes a snapshot to **`avd_artist_market_top_tracks`**.
+- The consumer **upserts** into Mongo (one doc per `(user, artist, market)`).
+
+### 4) Streamlit dashboard (new)
+- App file: **`src/app/streamlit_app.py`**.
+- Reads directly from MongoDB (no Kafka needed to view historical data).
+- Pages/sections:
+  - **Recent plays** (table, with UTC time)
+  - **Top artists** (bar chart by play counts)
+  - **Top tracks** (bar chart by play counts)
+  - **Latest Top‑10 docs** (expandable rows to see tracks inside the snapshot)
+- Date range filtering (UTC) + simple caching for snappy UX.
 
 ---
 
-## 🔄 Next Steps
-- **Real-time Processing (Spark Structured Streaming)**:
-  - Consume events from Kafka (`spotify_recent_events`).
-  - Compute aggregates such as top artists, top tracks, and time distribution of plays.
-  - Persist results into storage.
+## Key files in the repo
 
-- **Storage & Persistence**:
-  - Explore queries over MongoDB data.
-  - Decide on additional storage format: Parquet files, or SQL/NoSQL DB.
-
-- **Visualization (Streamlit)**:
-  - Build a dashboard to display top artists and tracks.
-  - Use simple charts (bar charts, timelines).
-
-- **Documentation (Jupyter Notebook)**:
-  - Create an end-to-end pipeline notebook: API → Kafka → MongoDB/Spark → Storage → Visualization.
-  - Include screenshots, code snippets, and explanations.
-
-- **Optional Enhancements**:
-  - Extend `docker-compose.yml` with Spark and Streamlit services.
-  - Automate the entire pipeline for one-command startup.
+- **`src/DE-Spotify.py`** — Spotify producer (API → Kafka).
+- **`src/kafka_consumer.py`** — Kafka consumer (Kafka → MongoDB).
+- **`src/spotify_payloads.py`** — Payload dataclass & builders for per‑play events.
+- **`src/kafka_producer.py`** — Small helper used by the producer to push JSON to Kafka.
+- **`src/app/streamlit_app.py`** — Streamlit dashboard reading from Mongo.
+- **`src/makefile`** — Commands for Docker, topics, produce/consume, and helpers (see Setup).
+- **`docker-compose.yml`** — Zookeeper, Kafka, MongoDB, Mongo‑Express.
 
 ---
 
-## 📌 Conclusion
-- Current stage: **Data ingestion + Kafka + MongoDB working** ✅  
-- Next stage: **Spark Streaming for real-time processing and storage**.  
-- Final stage: **Visualization and documentation** to deliver a complete project that satisfies the professor’s requirements.
+## Topics & collections (mine)
 
+| Layer  | Mine (prefix `avd_`)                  | What it’s for                                  |
+|--------|---------------------------------------|------------------------------------------------|
+| Kafka  | `avd_spotify_recent_events`          | Per‑play events                                |
+| Kafka  | `avd_artist_market_top_tracks`       | Top‑10 snapshot for dominant artist/market     |
+| Mongo  | `avd_recent_events`                  | Append‑only, dedup by (user,track,played_at)   |
+| Mongo  | `avd_artist_market_top_tracks`       | One doc per (user, artist, market), latest only|
+
+> `__consumer_offsets` is Kafka’s internal system topic — **do not delete**.
+
+---
+
+## Recent changes (high‑level)
+
+- **Makefile refactor**:  
+  - Introduced `KAFKA_CONTAINER` variable (defaults to `kafka`) to avoid hardcoding the container name.
+  - Grouped topic commands (`kafka-init`, `kafka-list`, `kafka-delete`).
+  - Added **env helpers**: `env-avd`, `env-alex`, `env-bogdan` and **one‑shot run targets** `run-avd`, `run-alex`, `run-bogdan` (copy team‑specific `.env.*` before running).
+- **Streamlit** app added under `src/app` with Mongo queries that are safe for the array fields (`artist_ids`, `artist_names`).
+- **Mongo indexes** are idempotent and aligned with the payloads.
+
+---
+
+## How we validate
+
+- Kafka: `make kafka-list`, `make kafka-init`, console producer/consumer smoke tests.
+- Mongo: quick `mongosh` queries to inspect documents and verify indexes.
+- Streamlit: run locally and filter by date; see bar charts populate.
+
+---
+
+## Known quirks & troubleshooting
+
+- **Kafka "Broker may not be available"** right after `docker compose up`: wait a few seconds; if it persists → `make down && make up` then `make kafka-init`.
+- **Zookeeper timeouts**: same as above; check container health with `docker ps` and `docker logs`.
+- **Topic with underscore warning**: benign in our single‑broker dev setup.
+- **Duplicate index names** in Mongo: the consumer already handles index creation idempotently. If you changed names manually in the past, drop the old index or drop the collection once (dev only).
+
+---
+
+## Next steps (proposal)
+
+- **Team stories**: each colleague adds their **own topics & collections** using a personal prefix (see Setup Guide).
+- **Streamlit**: add tabs per teammate, and market/date filters across all widgets.
+- **(Optional)** Spark Structured Streaming from Kafka for near‑real‑time aggregations.
+- **Notebook**: one Jupyter file documenting the pipeline with screenshots, sample queries, and references to code paths.
+
+---
+
+## Data & privacy notes
+
+- OAuth tokens are per‑user; never commit your `.env`.
+- Team demo can be done on one laptop by importing multiple Mongo DBs (each with separate prefixes) and switching `.env` with Make targets (`run-avd`, `run-alex`, …).

--- a/src/app/streamlit_app.py
+++ b/src/app/streamlit_app.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Streamlit dashboard for Spotify pipeline (multi-owner friendly).
+
+Reads from MongoDB:
+- <prefix>_recent_events (append-only play events)
+- <prefix>_artist_market_top_tracks (latest top10 per dominant artist & market)
+
+ENV (optional):
+	# Mongo
+	MONGO_URL  = "mongodb://root:example@localhost:27017/?authSource=admin"
+	MONGO_DB   = "spotify_db"
+
+	# Owner/prefix convention so each colleague can have isolated collections
+	OWNER_PREFIX = "avd"  # e.g., "alex", "bogdan", ...
+
+	# (Advanced) Override collection names explicitly if needed
+	COLL_EVENTS = "avd_recent_events"
+	COLL_TOP10  = "avd_artist_market_top_tracks"
+
+Run:
+	streamlit run src/app/streamlit_app.py
+"""
+
+import os
+from datetime import datetime, timezone, date, time
+from typing import Optional, Tuple, List
+
+import pandas as pd
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError
+import streamlit as st
+
+# -----------------------------
+# Config (env with safe defaults; supports team prefixes)
+# -----------------------------
+MONGO_URL = os.getenv("MONGO_URL", "mongodb://root:example@localhost:27017/?authSource=admin")
+DB_NAME   = os.getenv("MONGO_DB",  "spotify_db")
+
+OWNER_PREFIX = os.getenv("OWNER_PREFIX", "avd").strip() or "avd"
+DEFAULT_COLL_EVENTS = f"{OWNER_PREFIX}_recent_events"
+DEFAULT_COLL_TOP10  = f"{OWNER_PREFIX}_artist_market_top_tracks"
+
+# Allow explicit overrides via env if a colleague wants custom names
+COLL_EVENTS = os.getenv("COLL_EVENTS", DEFAULT_COLL_EVENTS)
+COLL_TOP10  = os.getenv("COLL_TOP10",  DEFAULT_COLL_TOP10)
+
+# -----------------------------
+# Mongo helpers (cached)
+# -----------------------------
+@st.cache_resource(show_spinner=False)
+def _get_db():
+	"""Create a single Mongo client per Streamlit session and return the DB handle."""
+	client = MongoClient(MONGO_URL)
+	return client[DB_NAME]
+
+# -----------------------------
+# Common pipeline piece: normalize fields to arrays
+# This makes the UI robust even if some older docs stored strings/nulls.
+# -----------------------------
+PIPE_NORMALIZE_ARTISTS = [
+	{
+		"$set": {
+			"artist_ids_norm": {
+				"$cond": [
+					{ "$isArray": "$artist_ids" },
+					"$artist_ids",
+					{ "$cond": [ { "$eq": [ "$artist_ids", None ] }, [], [ "$artist_ids" ] ] }
+				]
+			},
+			"artist_names_norm": {
+				"$cond": [
+					{ "$isArray": "$artist_names" },
+					"$artist_names",
+					{ "$cond": [ { "$eq": [ "$artist_names", None ] }, [], [ "$artist_names" ] ] }
+				]
+			}
+		}
+	}
+]
+
+def _utc_range(d_from: date, d_to: date) -> Tuple[datetime, datetime]:
+	"""Helper: convert two date objects to full-day UTC datetime interval."""
+	start = datetime.combine(d_from, time.min, tzinfo=timezone.utc)
+	end   = datetime.combine(d_to,   time.max, tzinfo=timezone.utc)
+	return start, end
+
+@st.cache_data(show_spinner=False, ttl=60)
+def _load_recent_events(
+	date_range: Optional[Tuple[datetime, datetime]] = None,
+	limit: int = 5000
+) -> pd.DataFrame:
+	"""Load recent events with safe projection; attach parsed datetime for UI."""
+	try:
+		db = _get_db()
+		q = {}
+		if date_range:
+			start, end = date_range
+			# played_at is string in UTC → lexicographic filter works
+			q["played_at"] = {"$gte": start.isoformat(), "$lte": end.isoformat()}
+
+		cur = db[COLL_EVENTS].find(
+			q,
+			{
+				"_id": 0,
+				"user_id": 1,
+				"played_at": 1,
+				"track_id": 1,
+				"track_name": 1,
+				"artist_ids": 1,
+				"artist_names": 1,
+				"album_id": 1,
+				"album_name": 1,
+				"country": 1,
+				"market_used": 1,
+			},
+		).sort("played_at", -1).limit(int(limit))
+		df = pd.DataFrame(list(cur))
+		if not df.empty:
+			df["played_at_dt"] = pd.to_datetime(df["played_at"], utc=True, errors="coerce")
+		return df
+	except PyMongoError as e:
+		st.error(f"Mongo error while loading events: {e}")
+		return pd.DataFrame()
+
+@st.cache_data(show_spinner=False, ttl=60)
+def _top_artists(
+	limit: int = 20,
+	date_range: Optional[Tuple[datetime, datetime]] = None
+) -> pd.DataFrame:
+	"""Compute top artists by play count, robust to mixed schemas."""
+	try:
+		db = _get_db()
+		match = {}
+		if date_range:
+			start, end = date_range
+			match["played_at"] = {"$gte": start.isoformat(), "$lte": end.isoformat()}
+
+		pipeline: List[dict] = []
+		pipeline += PIPE_NORMALIZE_ARTISTS
+		pipeline.append({ "$match": match } if match else { "$match": {} })
+		pipeline += [
+			{ "$unwind": "$artist_ids_norm" },
+			{ "$group": { "_id": "$artist_ids_norm", "plays": { "$sum": 1 } } },
+			{ "$sort": { "plays": -1 } },
+			{ "$limit": int(limit) },
+
+			# Best-effort to fetch a representative name without assuming aligned arrays
+			{
+				"$lookup": {
+					"from": COLL_EVENTS,
+					"localField": "_id",
+					"foreignField": "artist_ids",  # matches any doc where artist_ids array contains _id
+					"as": "sample_docs"
+				}
+			},
+			{
+				"$set": {
+					"artist_name": {
+						"$let": {
+							"vars": { "first": { "$first": "$sample_docs" } },
+							"in": {
+								"$cond": [
+									{ "$gt": [ { "$size": { "$ifNull": [ "$$first.artist_names", [] ] } }, 0 ] },
+									{ "$arrayElemAt": [ "$$first.artist_names", 0 ] },
+									"Unknown"
+								]
+							}
+						}
+					}
+				}
+			},
+			{ "$project": { "_id": 0, "artist_id": "$_id", "artist_name": 1, "plays": 1 } }
+		]
+
+		rows = list(db[COLL_EVENTS].aggregate(pipeline))
+		df = pd.DataFrame(rows)
+		return df
+	except PyMongoError as e:
+		st.error(f"Mongo error while computing top artists: {e}")
+		return pd.DataFrame()
+
+@st.cache_data(show_spinner=False, ttl=60)
+def _top_tracks(
+	limit: int = 20,
+	date_range: Optional[Tuple[datetime, datetime]] = None
+) -> pd.DataFrame:
+	"""Compute top tracks by play count (groups by track_id & track_name)."""
+	try:
+		db = _get_db()
+		match = {}
+		if date_range:
+			start, end = date_range
+			match["played_at"] = {"$gte": start.isoformat(), "$lte": end.isoformat()}
+
+		pipeline = [
+			{ "$match": match } if match else { "$match": {} },
+			{
+				"$group": {
+					"_id": { "track_id": "$track_id", "track_name": "$track_name" },
+					"plays": { "$sum": 1 },
+					"any_artist_names": { "$first": "$artist_names" },
+				}
+			},
+			{ "$sort": { "plays": -1 } },
+			{ "$limit": int(limit) },
+		]
+		rows = list(db[COLL_EVENTS].aggregate(pipeline))
+		df = pd.DataFrame(rows)
+		if not df.empty:
+			df["track_id"] = df["_id"].apply(lambda x: (x or {}).get("track_id"))
+			df["track_name"] = df["_id"].apply(lambda x: (x or {}).get("track_name"))
+			df.drop(columns=["_id"], inplace=True, errors="ignore")
+		return df
+	except PyMongoError as e:
+		st.error(f"Mongo error while computing top tracks: {e}")
+		return pd.DataFrame()
+
+@st.cache_data(show_spinner=False, ttl=60)
+def _latest_top10_docs(limit: int = 20) -> pd.DataFrame:
+	"""Load the latest generated 'Top 10 for dominant artist' documents."""
+	try:
+		db = _get_db()
+		cur = db[COLL_TOP10].find({}, {"_id": 0}).sort("generated_at", -1).limit(int(limit))
+		df = pd.DataFrame(list(cur))
+		return df
+	except PyMongoError as e:
+		st.error(f"Mongo error while loading top10 docs: {e}")
+		return pd.DataFrame()
+
+# -----------------------------
+# UI
+# -----------------------------
+st.set_page_config(page_title="Spotify Dashboard (Team-ready)", page_icon="🎧", layout="wide")
+st.title("Spotify Dashboard")
+
+with st.sidebar:
+	st.header("Filters")
+	st.caption(f"Mongo DB: **{DB_NAME}**, Collections: **{COLL_EVENTS}**, **{COLL_TOP10}**")
+
+	utc_now = datetime.now(timezone.utc)
+	default_from = utc_now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+	date_from = st.date_input("From (UTC date)", default_from.date())
+	date_to   = st.date_input("To (UTC date)", utc_now.date())
+	top_k = st.slider("Top K", min_value=5, max_value=50, value=10, step=5)
+	show_limit = st.selectbox("Recent plays limit", options=[100, 250, 500, 1000, 5000], index=2)
+
+	date_range = _utc_range(date_from, date_to)
+
+# -----------------------------
+# Recent plays
+# -----------------------------
+st.subheader("Recent plays")
+df_recent = _load_recent_events(date_range=date_range, limit=int(show_limit))
+st.caption(f"{len(df_recent)} rows")
+if df_recent.empty:
+	st.info(f"No data found in {COLL_EVENTS} for the selected range.")
+else:
+	st.dataframe(
+		df_recent[["played_at_dt", "track_name", "artist_names", "album_name", "market_used"]]
+		.rename(columns={"played_at_dt": "played_at"}),
+		use_container_width=True,
+	)
+
+# -----------------------------
+# Side-by-side: Top artists / Top tracks
+# -----------------------------
+col1, col2 = st.columns(2, gap="large")
+
+with col1:
+	st.subheader("Top artists (by plays)")
+	df_art = _top_artists(limit=top_k, date_range=date_range)
+	if df_art.empty:
+		st.info("No artist data found.")
+	else:
+		df_art["label"] = df_art["artist_name"].fillna(df_art["artist_id"])
+		st.bar_chart(df_art.set_index("label")["plays"])
+		st.dataframe(df_art[["artist_id", "artist_name", "plays"]], use_container_width=True)
+
+with col2:
+	st.subheader("Top tracks (by plays)")
+	df_tr = _top_tracks(limit=top_k, date_range=date_range)
+	if df_tr.empty:
+		st.info("No track data found.")
+	else:
+		df_tr["label"] = df_tr["track_name"].fillna(df_tr["track_id"])
+		st.bar_chart(df_tr.set_index("label")["plays"])
+		st.dataframe(
+			df_tr[["track_id", "track_name", "any_artist_names", "plays"]]
+				.rename(columns={"any_artist_names": "artist_names"}),
+			use_container_width=True,
+		)
+
+# -----------------------------
+# Latest Top 10 docs
+# -----------------------------
+st.subheader("Latest ‘Top 10 for dominant artist in market’ docs")
+df_top10 = _latest_top10_docs(limit=10)
+if df_top10.empty:
+	st.info(f"No documents in {COLL_TOP10} yet.")
+else:
+	cols = ["generated_at", "market", "artist_name", "artist_id", "user_id"]
+	existing_cols = [c for c in cols if c in df_top10.columns]
+	if existing_cols:
+		st.dataframe(df_top10[existing_cols], use_container_width=True)
+	else:
+		st.dataframe(df_top10, use_container_width=True)
+
+	for i, row in df_top10.iterrows():
+		title = f"{row.get('artist_name','?')} · {row.get('market','?')} · {row.get('generated_at','?')}"
+		with st.expander(title):
+			tracks = pd.DataFrame(row.get("tracks") or [])
+			if not tracks.empty:
+				show_cols = [c for c in ["rank", "track_name", "duration_ms", "album_name", "artists"] if c in tracks.columns]
+				if "rank" in show_cols:
+					st.dataframe(tracks[show_cols].set_index("rank"), use_container_width=True)
+				else:
+					st.dataframe(tracks[show_cols], use_container_width=True)
+			else:
+				st.write("No tracks array.")
+

--- a/src/setup.md
+++ b/src/setup.md
@@ -1,164 +1,252 @@
-# Project Setup Guide
+# Project Setup Guide (with team onboarding)
 
-This document explains how the current project works (mine = Dorin’s part), and how each teammate can add their own user stories without interfering with others.
-
----
-
-## 0) Current State (mine)
-
-The project already implements ingestion for my two user stories:
-
-- **US1 (Leaderboard / Recent Plays):**
-  - `avd_recent_events` in Kafka → `avd_recent_events` collection in Mongo
-  - Each play (user_id + track_id + played_at) is stored as an event.
-  - Deduplicated by index `(user_id, track_id, played_at)`
-
-- **US2 (Top 10 Tracks for Dominant Artist in Market):**
-  - `avd_artist_market_top_tracks` in Kafka → `avd_artist_market_top_tracks` in Mongo
-  - One document per run with **Top 10 tracks** for the most played artist in the last 50 plays.
-  - Upsert key: `(user_id, artist_id, market)` → always keeps the latest snapshot.
+This guide explains how to **run the project**, how **my** part (Dorin, prefix `avd_`) works, and how teammates can plug in their **own user stories** without interfering. All steps are **Docker‑first**; local installs are optional.
 
 ---
 
-## 1) Repository Structure (important files)
+## 1) Prerequisites
 
-- `src/DE-Spotify.py` → Producer (Spotify → Kafka)  
-- `src/kafka_consumer.py` → Consumer (Kafka → Mongo)  
-- `src/spotify_payloads.py` → Payload schemas/builders  
-- `src/kafka_producer.py` → Utility for publishing to Kafka  
-- `src/makefile` → Defines targets (`make run`, `make consume`, etc.)  
-- `docker-compose.yml` → Runs Kafka, Zookeeper, and Mongo  
+- Docker & Docker Compose
+- Python 3.11+ (only if you want to run producer/consumer locally, outside of containers)
+- Spotify Developer credentials (per teammate): `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`
+- A personal `.env` with your Spotify auth settings (never commit it).
+
+Repo layout (top‑level):
+```
+/docs
+/notebooks
+/src
+  /app                 # Streamlit UI
+  docker-compose.yml   # (sometimes placed at repo root; adapt paths accordingly)
+  makefile
+  DE-Spotify.py        # Producer
+  kafka_consumer.py    # Consumer
+  kafka_producer.py    # Kafka helper
+  spotify_payloads.py  # Payload dataclasses
+  mongo_init/          # (optional seed/init)
+  envs/                # (optional) per-user env files, e.g. .env.avd, .env.alex
+```
+> Your actual repo may keep `docker-compose.yml` at root — both patterns work as long as Makefile paths match.
 
 ---
 
-## 2) Environment Variables (`.env`)
+## 2) Environment management (per teammate)
 
-Each member needs their own `.env` file:
+Each teammate keeps **their own** `.env`. For team demos you can store copies in `src/envs/`:
+```
+src/envs/.env.avd
+src/envs/.env.alex
+```
+**Important:** these files are **local only**; do not commit secrets.
 
+### Example `.env` (minimal)
 ```ini
+# Spotify
 CLIENT_ID=...
 CLIENT_SECRET=...
 USERNAME=...
-REDIRECT_URI=...
+REDIRECT_URI=http://localhost:8080/callback
 
-MARKET_OVERRIDE=AT   # Optional; defaults to Spotify profile country
+# Market/country
+MARKET_OVERRIDE=AT
 
+# Kafka & Mongo
 KAFKA_ENABLED=true
 KAFKA_BOOTSTRAP=localhost:9092
-
 MONGO_URL=mongodb://root:example@localhost:27017/?authSource=admin
 MONGO_DB=spotify_db
 GROUP_ID=spotify-consumer
 
+# Misc
 DEBUG=true
+```
+
+### Makefile env helpers
+The Makefile exposes convenience targets (copy your env then run):
+```make
+env-avd:      ## copy src/envs/.env.avd to src/.env
+	cp src/envs/.env.avd src/.env
+
+env-alex:
+	cp src/envs/.env.alex src/.env
+
+
+run-avd: env-avd run   ## run producer with Dorin's env
+run-alex: env-alex run ## run producer with Alex's env
+
+```
+> If your Makefile doesn’t have these yet, add them (safe to include; they don’t affect others).
+
+---
+
+## 3) Start infrastructure
+
+From `src/` (where the Makefile lives):
+```bash
+make up              # docker compose up -d (Kafka, ZK, Mongo, Mongo-Express)
+make kafka-init      # creates topics if not existing
+make kafka-list      # sanity check topics
+```
+**Defaults**
+- `KAFKA_CONTAINER=kafka` (override if your container has a different name)
+- Topics (mine): `avd_spotify_recent_events`, `avd_artist_market_top_tracks`
+
+If `kafka-init` prints “Broker may not be available”, wait a few seconds. If still failing:
+```bash
+make down && make up && make kafka-init
 ```
 
 ---
 
-## 3) Infrastructure Setup
+## 4) Run the pipeline (mine)
 
-1. Start Kafka, Zookeeper, and Mongo:
-   ```bash
-   docker compose up -d
-   ```
+Open **two terminals** in `src/`:
 
-2. Create Kafka topics via `make run`.
+**Terminal A — Consumer → Mongo**
+```bash
+make consume   # runs kafka_consumer.py (idempotent upserts)
+```
 
-3. Start the consumer:
-   ```bash
-   make consume
-   ```
+**Terminal B — Producer → Kafka**
+```bash
+make run       # runs DE-Spotify.py with your current src/.env
+# or, if you use per-user env shortcuts:
+make run-avd
+# make run-alex
+```
 
-4. Run the producer:
-   ```bash
-   make run
-   ```
+What happens:
+- Producer sends **per‑play events** to `avd_spotify_recent_events`.
+- Producer also sends **Top‑10 snapshot** for dominant artist to `avd_artist_market_top_tracks`.
+- Consumer writes to Mongo:
+  - `avd_recent_events` (unique key `(user_id, track_id, played_at)`)
+  - `avd_artist_market_top_tracks` (upsert key `(user_id, artist_id, market)`)
 
 ---
 
-## 4) Naming Convention (critical)
+## 5) Streamlit dashboard
 
-To avoid mixing data:  
-- **My data (Dorin) is always prefixed with `avd_`**:
-  - Topics: `avd_recent_events`, `avd_artist_market_top_tracks`
-  - Mongo collections: `avd_recent_events`, `avd_artist_market_top_tracks`
+Run locally (from repo root or `src/` — adjust path accordingly):
+```bash
+# inside the project venv (recommended):
+.venv/bin/streamlit run src/app/streamlit_app.py
+# or, if streamlit is installed globally:
+streamlit run src/app/streamlit_app.py
+```
+What you get:
+- **Recent plays** table (UTC time), **Top artists**, **Top tracks** bar charts.
+- **Latest Top‑10** snapshot viewer.
+- Date filters & page‑level caches.
 
-Each teammate must use their **own prefix** (e.g., `ap_`, `vs_`, etc.).
+> The app expects the collections to be named like mine. If teammates add their own collections, they can either extend the app with tabs or spin a separate app file for their prefix.
 
-Example for Alex Popescu (`ap`):
+---
+
+## 6) Add **your** user story (template & steps)
+
+### Naming convention (critical)
+Use **your own prefix** everywhere (Kafka topic name + Mongo collection name). Example for Alex (`ap_`):
 - Topic: `ap_playlist_quality`
 - Collection: `ap_playlist_quality`
 
+### Files to touch
+1) **`src/spotify_payloads.py`**
+   - Add a **dataclass** for your event/snapshot payload(s).
+   - Add **builder(s)** that turn Spotify JSON into your dataclass(es).
+
+2) **`src/DE-Spotify.py`** (producer)
+   - After/around my code paths, call your Spotify API, build your payload(s), then publish to **your** topic using the existing Kafka helper.
+
+3) **`src/kafka_consumer.py`** (consumer)
+   - In `_build_mongo()`: create **your** collection and indexes (unique key for events; upsert key for snapshots).
+   - In `subscribe([...])`: add **your** topic.
+   - In the message router: add a handler like `_upsert_ap_playlist_quality(...)` to insert/upsert in your collection.
+
+4) **`docs/_template_user_story.md`** → copy to `docs/<prefix>_user_story.md` and fill it in.
+
+> Do **not** rename or modify my topics/collections; add your own in parallel. This keeps data clean for each teammate.
+
 ---
 
-## 5) Adding Your Own User Story
+## 7) Quick Mongo sanity checks
 
-Each teammate must:
+```bash
+# One recent play
+docker exec -it mongo mongosh "mongodb://root:example@mongo:27017/spotify_db?authSource=admin" \
+  --eval 'db.avd_recent_events.findOne({}, {track_name:1, artist_names:1, played_at:1, _id:0})'
 
-### A) Define a New Kafka Topic
-- In the `makefile`, add a line in the Kafka topic creation section:
-  ```make
-  docker exec -it kafka kafka-topics --create --if-not-exists     --topic ap_playlist_quality --bootstrap-server localhost:9092     --partitions 1 --replication-factor 1
-  ```
+# Top artists by plays
+docker exec -it mongo mongosh "mongodb://root:example@mongo:27017/spotify_db?authSource=admin" \
+  --eval 'db.avd_recent_events.aggregate([{$unwind:"$artist_ids"},{$group:{_id:"$artist_ids",plays:{$sum:1}}},{$sort:{plays:-1}},{$limit:10}]).toArray()'
 
-### B) Add a Payload Schema
-- In `src/spotify_payloads.py`, add a **new dataclass** for your payload.
-- Use the same style as `SpotifyPlayEvent` but with fields relevant to your user story.
-- Add a builder function for creating your payload from Spotify API data.
+# Latest Top-10 doc
+docker exec -it mongo mongosh "mongodb://root:example@mongo:27017/spotify_db?authSource=admin" \
+  --eval 'db.avd_artist_market_top_tracks.find().sort({generated_at:-1}).limit(1).pretty()'
+```
 
-### C) Extend the Producer
-- In `src/DE-Spotify.py`, after my code finishes producing, add your own logic:
-  - Fetch from Spotify API (or reuse my access tokens).
-  - Build your payload with your builder function.
-  - Send to your topic with `KafkaJsonProducer`.
+---
 
-### D) Extend the Consumer
-1. In `_build_mongo()` (inside `kafka_consumer.py`):
-   - Add a handle for your collection:
-     ```python
-     c_ap = db["ap_playlist_quality"]
+## 8) Troubleshooting
+
+- **Kafka “Broker may not be available”**: containers might still be starting. `make down && make up`, then `make kafka-init`.
+- **Consumer stuck / offsets**: stop `make consume`, start again; for full replay create a **new** consumer group (`GROUP_ID`) or reset offsets.
+- **Topic cleanup** (dev only): `make kafka-delete TOPIC=name` to remove a bad topic; then `make kafka-init`.
+- **Mongo index conflicts**: if you changed index names manually earlier, drop the collection in dev and let the consumer recreate clean indexes.
+- **`__consumer_offsets`**: Kafka’s system topic, expected to be there.
+
+---
+
+## 9) Team demo plan
+
+- Each teammate runs **their own** producer against **their own** Spotify account (with their `.env`).
+- For a single‑laptop demo, you can **import Mongo backups** from everyone into one Mongo instance. Prefixes avoid collisions.
+- Use the Makefile env helpers (`run-avd`, `run-alex`) to switch identities quickly.
+- Streamlit can either show **Dorin’s** data only (current file) or be extended with tabs for each prefix.
+
+---
+
+## 10) Security
+
+- Never commit any `.env` or tokens.
+- If you back up Mongo, do not share raw dumps publicly — keep them within the team or anonymize.
+
+
+## 11) How to add your own producer
+
+Each team member can implement their own Kafka producer without interfering with others.  
+The convention is to use your own prefix (e.g., `avd_`, `alex_`, etc.) for both Kafka topics and MongoDB collections.
+
+### Steps
+
+1. **Create your producer file**  
+   - Copy the existing `src/kafka_producer.py` or `src/topic_producer/example_producer.py` as a template.  
+   - Save it as `src/topic_producer/<yourname>_producer.py`.  
+   - Adjust the code to produce your own events.
+
+2. **Define your topic(s)**  
+   - Choose a topic name with your prefix, e.g. `alex_recent_events`.  
+   - In `makefile`, add an entry under the Kafka section:  
+     ```make
+     run-alex:  # run producer with Alex's env
+     	.venv/bin/python3 src/topic_producer/alex_producer.py
      ```
-   - Add indexes:
-     - For events: unique key like `(user_id, played_at, track_id)`
-     - For snapshots: upsert key like `(user_id, playlist_id)`
 
-2. In `consumer.subscribe([...])`:
-   - Add your topic to the list.
+3. **Configure MongoDB collection**  
+   - Make sure your consumer writes to a collection with your prefix (e.g., `alex_recent_events`).  
+   - This avoids collisions between users.
 
-3. In the main loop (router by `topic`):
-   - Add a branch:
-     ```python
-     elif topic == "ap_playlist_quality":
-         _upsert_ap_playlist_quality(c_ap, payload)
+4. **Add your Streamlit dashboard (optional)**  
+   - Create `src/app/streamlit_app_<yourname>.py`.  
+   - You can copy `streamlit_app.py` and adapt it to your data.
+
+5. **Test**  
+   - Run `make up` to start the infra.  
+   - Run your producer (`make run-alex`) to push events.  
+   - Start your consumer (`make consume`) and confirm events reach MongoDB.  
+   - Launch your dashboard with:  
+     ```bash
+     .venv/bin/streamlit run src/app/streamlit_app_alex.py
      ```
 
-4. Write `_upsert_ap_playlist_quality()` function to insert/upsert.
+Following this pattern, each teammate can work independently but still share the same infrastructure.
 
-### E) Document Your Story
-- Copy the template from `docs/_template_user_story.md`.
-- Fill in your details and save as `docs/<prefix>_user_story.md`.
-
----
-
-## 6) How to Verify Your Data
-
-Check that your producer and consumer work:
-
-1. Run producer (`make run`) and consumer (`make consume`).
-2. Verify Kafka logs:
-   - Should show `[KAFKA] Sent ... to <topic>`
-3. Verify Mongo logs:
-   - Should show `[MONGO] Inserted from <topic> ...`
-4. Check MongoDB:
-   ```bash
-   docker exec -it mongo mongosh "mongodb://root:example@mongo:27017/spotify_db?authSource=admin"      --eval 'db.ap_playlist_quality.findOne()'
-   ```
-
----
-
-## 7) Summary
-
-- **My topics/collections**: `avd_recent_events`, `avd_artist_market_top_tracks`  
-- **Your topics/collections**: must use your own prefix (`ap_`, `vs_`, etc.)  
-- Each user story = new topic + new collection + payload schema + producer logic + consumer handler.  
-- Never modify mine — only add your own sections.

--- a/src/topic_producer/example_producer.py
+++ b/src/topic_producer/example_producer.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Example Kafka producer template.
+- Each teammate should copy this file and rename it, e.g., alex_producer.py
+- Use your own topic prefix (e.g., alex_recent_events).
+- Adjust payload structure as needed.
+
+Run:
+	.venv/bin/python3 src/topic_producer/example_producer.py
+"""
+
+import os
+import json
+import time
+import random
+from datetime import datetime
+from kafka import KafkaProducer
+
+# -----------------------------
+# Config (env with safe defaults)
+# -----------------------------
+KAFKA_BOOTSTRAP = os.getenv("KAFKA_BOOTSTRAP", "localhost:9092")
+TOPIC_NAME = os.getenv("TOPIC_NAME", "example_recent_events")
+
+# -----------------------------
+# Kafka Producer (singleton)
+# -----------------------------
+def get_producer() -> KafkaProducer:
+	"""
+	Create a Kafka producer with JSON serialization.
+	"""
+	return KafkaProducer(
+		bootstrap_servers=KAFKA_BOOTSTRAP,
+		value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+		key_serializer=lambda v: str(v).encode("utf-8"),
+		retries=3,
+	)
+
+# -----------------------------
+# Example payload generator
+# -----------------------------
+def generate_fake_event(user_id: str) -> dict:
+	"""
+	Generate a fake play event (replace with real Spotify data if available).
+	"""
+	return {
+		"user_id": user_id,
+		"track_id": f"track_{random.randint(1, 100)}",
+		"track_name": f"Song {random.randint(1, 100)}",
+		"artist_ids": [f"artist_{random.randint(1, 10)}"],
+		"artist_names": [f"Artist {random.randint(1, 10)}"],
+		"album_id": f"album_{random.randint(1, 50)}",
+		"album_name": f"Album {random.randint(1, 50)}",
+		"market_used": random.choice(["US", "AT", "DE"]),
+		"played_at": datetime.utcnow().isoformat(),
+	}
+
+# -----------------------------
+# Main loop
+# -----------------------------
+if __name__ == "__main__":
+	producer = get_producer()
+	print(f"[INFO] Producer connected to {KAFKA_BOOTSTRAP}, sending to topic: {TOPIC_NAME}")
+
+	try:
+		while True:
+			event = generate_fake_event(user_id="example_user")
+			producer.send(TOPIC_NAME, key=event["user_id"], value=event)
+			print(f"[DEBUG] Sent event: {event}")
+			time.sleep(2)  # simulate delay between events
+	except KeyboardInterrupt:
+		print("\n[INFO] Stopping producer.")
+	finally:
+		producer.close()
+


### PR DESCRIPTION
- Implemented Streamlit dashboard (recent plays, top artists, top tracks, top10 docs) with MongoDB backend
- Fixed aggregation bug ( on string) by using  and regrouping
- Updated caching and query filters for flexibility
- Added detailed setup.md with new section 'How to add your own producer'
- Documented how teammates can add their own Kafka topics, producers, and dashboards
- STATUS.md updated to reflect current architecture and progress