### PR TITLE
Docs: update SETUP/STATUS for generic multi-user pipeline

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,203 +1,191 @@
+# Project Setup Guide (Generic • Multi‑User)
 
-# Project Setup Guide
-
+This repo is now **env‑driven and prefix‑agnostic**. Every teammate can run their own pipeline (own topics, own Mongo collections, optional own Streamlit tab) **without code changes**—just by providing a personal `.env` and, optionally, a small tab module.
 
 ---
 
 ## 1) Prerequisites
 
 - Docker & Docker Compose
-- Python 3.11+ (for running producer/consumer locally outside containers)
-- Spotify Developer credentials (per teammate): `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`
-- A personal `.env` file in `src/` (keep it local, do not commit)
+- Python 3.11+ (local dev; the infra runs in Docker)
+- (Optional) Spotify Developer credentials for producers that query Spotify
+- A **personal** `src/.env` (never commit secrets)
 
-### Repository layout (relevant parts)
+### Repository layout (relevant)
 ```
 /src
-  /app/                    # Streamlit UI
-  /consumers/              # Kafka → Mongo consumer(s)
+  app/                     # Streamlit UI (orchestrator + teammate tabs)
+    streamlit_app.py
+    tabs/
+      avd.py               # Dorin's tab (example)
+  consumers/               # Kafka → Mongo consumer(s)
     kafka_consumer.py
-  /lib/                    # shared helpers & dataclasses
+  lib/                     # shared utils
     kafka_producer.py
     spotify_payloads.py
-  /producers/              # Spotify → Kafka producer(s)
+  producers/               # producers (one per teammate or per use case)
     avd_producer.py
     example_producer.py
-  docker-compose.yml       # infra: Zookeeper, Kafka, Mongo, Mongo-Express
-  makefile                 # run targets
+  docker-compose.yml       # infra (ZK, Kafka, Mongo, Mongo-Express)
+  makefile                 # common tasks
+.env.example               # document all env vars
+envs/                      # per-user .env templates (NOT secrets)
 ```
+> Tip: put your templates in `src/envs/.env.<prefix>` and **never** commit a real `src/.env`.
 
 ---
 
-## 2) Environment
+## 2) Your `.env` (one per teammate)
 
-Place your runtime variables in `src/.env` or export them in your shell. Typical keys:
+Copy `src/.env.example` to `src/.env` (or use a template in `src/envs/`). Fill only what you need.
 
 ```ini
-# Spotify
-CLIENT_ID=...
-CLIENT_SECRET=...
-USERNAME=...
-REDIRECT_URI=http://localhost:8080/callback
+# Identity
+APP_PREFIX=alex
 
-# Market/country
-MARKET_OVERRIDE=AT  # optional; defaults to Spotify profile country
-
-# Kafka & Mongo
+# Kafka (host broker)
 KAFKA_BOOTSTRAP=localhost:9092
-GROUP_ID=spotify-consumer
+
+# The topics you will use (comma separated)
+KAFKA_TOPICS=alex_events,alex_metrics
+
+# Optional: route a topic to a semantic handler
+# Recognized handlers in consumer: events | top10
+# Unmapped topics are written RAW under GENERIC_COLL_NAMESPACE
+KAFKA_TOPIC_ROUTES=alex_events:events
+
+# Mongo
 MONGO_URL=mongodb://root:example@localhost:27017/?authSource=admin
 MONGO_DB=spotify_db
 
-# Optional overrides (defaults exist in code)
-TOPIC_EVENTS=avd_spotify_recent_events
-TOPIC_TOP10=avd_artist_market_top_tracks
-COLL_EVENTS=avd_recent_events
-COLL_TOP10=avd_artist_market_top_tracks
+# Collections for classic Spotify views (optional)
+# Leave empty if you don't have these; Streamlit hides sections automatically.
+MONGO_COLL_EVENTS=
+MONGO_COLL_TOP10=
+
+# Namespace for RAW topics → Mongo collections (required for generic flow)
+# e.g., topic "alex_events" → collection "alex__topic__alex_events"
+GENERIC_COLL_NAMESPACE=alex__topic__
+
+# (Optional) Spotify credentials if your producer hits Spotify
+CLIENT_ID=<...>
+CLIENT_SECRET=<...>
+USERNAME=<...>
+SPOTIPY_CLIENT_ID=<...>
+SPOTIPY_CLIENT_SECRET=<...>
+SPOTIPY_REDIRECT_URI=http://127.0.0.1:8888/callback
+
+# Which producer file to run on `make run-<prefix>`
+PRODUCER_ENTRY=src/producers/alex_producer.py
+
+# Misc
 DEBUG=true
+KAFKA_ENABLED=true
 ```
+
+**Rules of thumb**
+- Always set `APP_PREFIX`, `KAFKA_TOPICS`, `GENERIC_COLL_NAMESPACE`, and `PRODUCER_ENTRY`.
+- Only set `MONGO_COLL_EVENTS` / `MONGO_COLL_TOP10` if you actually produce that schema.
+- Use `KAFKA_TOPIC_ROUTES` only when a topic must be parsed with a specific handler (`events`, `top10`). Everything else is stored RAW safely.
 
 ---
 
 ## 3) Start infrastructure
 
 From `src/`:
-
 ```bash
-make up           # docker compose up -d (ZK, Kafka, Mongo, Mongo-Express)
-make kafka-init   # create topics if missing
-make kafka-list   # list topics
+make up                 # docker compose up -d (Kafka, ZK, Mongo, Mongo-Express)
+make kafka-init-from-env  # create topics found in KAFKA_TOPICS from current .env
+make kafka-list         # sanity-check topics
 ```
 
-Docker Compose file: `src/docker-compose.yml`
-
-Default topics created:
-- `avd_spotify_recent_events`
-- `avd_artist_market_top_tracks`
+Useful debugging:
+```bash
+make kafka-tail-topic TOPIC=alex_events
+make kafka-event-topic TOPIC=alex_events   # paste one JSON line, Ctrl+D
+make kafka-delete-topic TOPIC=alex_events  # careful
+```
 
 ---
 
-## 4) Run the pipeline
+## 4) Run consumer & your producer
 
-Open two terminals in `src/`:
+Open two terminals in `src/`.
 
-**Terminal A — Consumer → Mongo**
+**A) Consumer (Kafka → Mongo)**
 ```bash
-make consume        # runs: python -m consumers.kafka_consumer
+make consume           # runs: python -m consumers.kafka_consumer
 ```
 
-**Terminal B — Producer → Kafka**
+**B) Your producer**
+
+- If you have a template `.env` at `src/envs/.env.alex`:
 ```bash
-make run            # runs: python -m producers.avd_producer
+make run-alex          # copies envs/.env.alex → .env, creates topics, runs PRODUCER_ENTRY
+```
+- Or with the current `.env` already in place:
+```bash
+python -m producers.alex_producer
+# or: make run-avd   (Dorin's example producer)
 ```
 
-What happens:
-- Producer publishes per-play events to **Kafka topic** `avd_spotify_recent_events`.
-- Producer also publishes the **Top-10 snapshot for the dominant artist/market** to **Kafka topic** `avd_artist_market_top_tracks`.
-- Consumer writes to MongoDB:
-  - **Collection `avd_recent_events`** (append-only, unique on `(user_id, track_id, played_at)`).
-  - **Collection `avd_artist_market_top_tracks`** (upsert on `(user_id, artist_id, market)`, plus index on `generated_at` DESC).
+**What the consumer does**
+- Subscribes to **all topics listed in `KAFKA_TOPICS`** (so add yours there).
+- For topics mapped in `KAFKA_TOPIC_ROUTES`:
+  - `*:events` → normalized plays written to `MONGO_COLL_EVENTS` (or inferred)
+  - `*:top10`  → snapshot docs written to `MONGO_COLL_TOP10` (or inferred)
+- For everything else:
+  - Writes RAW documents to **`<GENERIC_COLL_NAMESPACE><topic>`**, e.g. `alex__topic__alex_metrics`.
 
 ---
 
-## 5) Streamlit dashboards (team tabs)
+## 5) Streamlit UI
 
-### 5.1 Run the dashboard
 From `src/`:
 ```bash
-.venv/bin/streamlit run app/streamlit_app.py
-# or: make app
-
-### 5.2 Configure teammates and tab labels
-
-Example configuration (src/app/team_config.yaml):
-
-
-### 5.3 Add a new tab
-
-Each teammate has a Python file under src/app/tabs/.
-
-Example (src/app/tabs/avd.py)
-
----
-
-## 6) Add your own producer
-
-1. Create a producer under `src/producers/<prefix>_producer.py`.
-2. Publish to your own topic(s) (use a personal prefix to avoid collisions).
-3. Extend the consumer in `src/consumers/kafka_consumer.py` (subscribe to your topic; route messages to a collection with your prefix; add indexes).
-4. Optionally add a Streamlit tab or a separate app file.
-
-Example Makefile snippet:
-```make
-run-alex:
-	$(PY) -m producers.alex_producer
+make app
+# or: python -m streamlit run app/streamlit_app.py
 ```
 
----
+There are **two ways** to show data:
 
+1) **Classic AVD tab** (`app/tabs/avd.py`)  
+   - Set `MONGO_COLL_EVENTS` / `MONGO_COLL_TOP10` in `.env`.  
+   - Displays Recent plays, Top artists/tracks, Daily plays, Plays per market, Top‑10 snapshots, and extra insights.
 
-## 7) Team demo plan
+2) **Orchestrator with team tabs** (if you use it)  
+   - `app/streamlit_app.py` loads tabs dynamically from `app/tabs/<prefix>.py`.  
+   - Each tab module must expose `render(db, cfg, prefix)` and can read from collections derived from that prefix.
 
-Each teammate runs their own producer against their own Spotify account (with their personal `.env`).  
-For a single-laptop demo, you can import Mongo backups from everyone into one Mongo instance. **Prefixes** avoid collisions.  
-
-- Use Makefile run targets (e.g. `make run-avd`, `make run-alex`) to switch identities quickly.  
-- Streamlit can either show one user’s data only (default `streamlit_app.py`) or be extended with tabs per prefix.  
-
----
-
-## 8) Security
-
-- Never commit any `.env` file or tokens.  
-- If you back up Mongo, do not share raw dumps publicly — keep them within the team or anonymize them.  
+If you only push RAW topics under `GENERIC_COLL_NAMESPACE`, you can build a simple explorer tab that lists collections starting with your prefix and renders them (examples exist in `avd.py`).
 
 ---
 
-## 9) How to add your own producer
+## 6) Add your own producer (quick path)
 
-Each team member can implement their own Kafka producer without interfering with others.  
-The convention is to use your own prefix (e.g., `avd_`, `alex_`, etc.) for both Kafka topics and MongoDB collections.
-
-### Steps
-
-**1. Create your producer file**  
-- Copy `src/producers/example_producer.py` as a template.  
-- Save it as `src/producers/<yourname>_producer.py`.  
-- Adjust the code to produce your own events, using your prefix.
-
-**2. Define your Kafka topic(s)**  
-- Choose a topic name with your prefix, e.g. `alex_recent_events`.  
-- In the Makefile, add a run target, for example:  
-```make
-run-alex:  # run producer with Alex's env
-	$(PY) -m producers.alex_producer
-```
-
-**3. Configure MongoDB collection**  
-- Make sure the consumer writes to a collection with your prefix (e.g., `alex_recent_events`).  
-- This avoids collisions between users.
-
-**4. Add your Streamlit dashboard (optional)**  
-- Create `src/app/streamlit_app_<yourname>.py`.  
-- You can copy `streamlit_app.py` and adapt it to your data.
-
-**5. Test**  
+1. Copy `src/producers/example_producer.py` → `src/producers/<prefix>_producer.py` and implement your logic.
+2. Edit your `.env`:
+   - `APP_PREFIX=<prefix>`
+   - `KAFKA_TOPICS=<your_topic1>,<your_topic2>`
+   - `PRODUCER_ENTRY=src/producers/<prefix>_producer.py`
+   - `GENERIC_COLL_NAMESPACE=<prefix>__topic__`
+3. Create topics and run:
 ```bash
-make up
-make run-alex
+make run-<prefix>      # example: make run-alex
 make consume
-.venv/bin/streamlit run src/app/streamlit_app_alex.py
+make app
 ```
 
-Following this pattern, each teammate can work independently but still share the same infrastructure.
+---
+
+## 7) Troubleshooting
+
+- **Topic keeps reappearing:** A producer can auto‑create topics if `allow.auto.create.topics=true`. Remove that in producer config or keep the topic.
+- **UI section hidden:** It becomes visible only when the corresponding `MONGO_COLL_*` env var is set (and collection has documents).
+- **Nothing is inserted:** Check `KAFKA_TOPICS`, `KAFKA_BOOTSTRAP`, and consumer logs; tail your topic with `make kafka-tail-topic`.
+- **Auth errors in Spotify:** match `SPOTIPY_*` with `CLIENT_ID/SECRET`, and keep the same `REDIRECT_URI` in the Spotify app settings.
+- **Do not commit secrets:** only commit `.env.example` and `envs/.env.<prefix>.example` templates.
 
 ---
 
 
-## 10) Troubleshooting
-
-- If Kafka just started, run `make kafka-init` after a short wait.
-- If offsets are stuck, change `GROUP_ID` to replay from scratch.
-- If index conflicts occur, drop the dev collection once; consumer recreates indexes idempotently.
-- `__consumer_offsets` is Kafka’s internal topic — ignore it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,93 +1,80 @@
+# Project Status — Generic, Multi‑User Spotify Data Engineering
 
-# Project Status — Spotify Data Engineering
-
+_Last updated: today_
 
 ---
 
-## End-to-end pipeline (prefix `avd_`)
+## Current pipeline (Dorin / `avd`)
 
-### 1) Spotify → Kafka (producer)
-- Module: **`src/producers/avd_producer.py`** (invoked via `python -m producers.avd_producer`).
-- Pulls last 50 recently played tracks; builds one event per play.
-- Publishes per-play events to Kafka topic: **`avd_spotify_recent_events`**.
+**Producer**: `src/producers/avd_producer.py`  
+- Pulls last 50 recent plays from Spotify and computes a "dominant artist Top‑10" for a market.  
+- Publishes to Kafka topics listed in `.env`:
+  - `avd_spotify_recent_events` (events)
+  - `avd_artist_market_top_tracks` (top10 snapshot)
 
-**Event schema (simplified):**
-```json
-{
-  "event_version": "1.0",
-  "event_type": "recent_play",
-  "generated_at": "...",
-  "user_id": "...",
-  "country": "AT",
-  "market_used": "DE",
-  "played_at": "...",
-  "track_id": "...",
-  "track_name": "...",
-  "album_id": "...",
-  "album_name": "...",
-  "album_release_date": "...",
-  "artist_ids": ["..."],
-  "artist_names": ["..."]
-}
+**Consumer**: `src/consumers/kafka_consumer.py`  
+- Subscribes to **all** topics from `KAFKA_TOPICS` (env).  
+- Routing:
+  - Topics mapped in `KAFKA_TOPIC_ROUTES`:
+    - `*:events`  → normalized plays → **`MONGO_COLL_EVENTS`** (or inferred)
+    - `*:top10`   → snapshot docs → **`MONGO_COLL_TOP10`** (or inferred)
+  - Others → RAW docs under **`<GENERIC_COLL_NAMESPACE><topic>`**.
+
+**Mongo**
+- Classic collections used by AVD tab:
+  - `avd_recent_events` (historical) or `avd_spotify_recent_events` (new) — pick via `.env`
+  - `avd_artist_market_top_tracks`
+- Generic collections (examples): `avd__topic__alex_events`, etc.
+
+**Streamlit**
+- Orchestrator: `app/streamlit_app.py` (loads tab modules under `app/tabs/`).  
+- Dorin’s tab: `app/tabs/avd.py` (robust schema handling; daily plays, per‑market, top artists/tracks, extra insights).
+
+**Makefile highlights**
+- `make up / down / logs`
+- `make kafka-init-from-env` — create topics from `KAFKA_TOPICS`
+- `make kafka-list` / `kafka-tail-topic TOPIC=...` / `kafka-event-topic TOPIC=...` / `kafka-delete-topic TOPIC=...`
+- `make consume` — start Kafka→Mongo writer
+- `make run-avd` — run Dorin’s producer
+- `make run-<prefix>` — run teammate (uses `envs/.env.<prefix>` → `.env` then runs `PRODUCER_ENTRY`)
+
+---
+
+## How teammates add their pipeline
+
+1) Create `src/envs/.env.<prefix>` with:
+- `APP_PREFIX=<prefix>`
+- `KAFKA_TOPICS=<topic_a>,<topic_b>`
+- `GENERIC_COLL_NAMESPACE=<prefix>__topic__`
+- `PRODUCER_ENTRY=src/producers/<prefix>_producer.py`
+- (optional) `MONGO_COLL_EVENTS` / `MONGO_COLL_TOP10`
+
+2) Write producer at `src/producers/<prefix>_producer.py` and publish to your topics.
+
+3) Run:
+```bash
+make run-<prefix>    # copies envs/.env.<prefix> → .env, creates topics, runs producer
+make consume
+make app
 ```
 
-### 2) Kafka → MongoDB (consumer)
-- Module: **`src/consumers/kafka_consumer.py`** (invoked via `python -m consumers.kafka_consumer`).
-- Subscribes to:
-  - `avd_spotify_recent_events`
-  - `avd_artist_market_top_tracks`
-- Writes to MongoDB:
-  - **`avd_recent_events`** (append-only). Indexes:
-    - Query index: `(user_id ASC, played_at DESC)`
-    - Unique: `(user_id, track_id, played_at)`
-  - **`avd_artist_market_top_tracks`** (snapshot per user/artist/market). Indexes:
-    - Unique: `(user_id, artist_id, market)`
-    - Sort index: `(generated_at DESC)`
-
-### 3) Dominant artist & Top-10 snapshot
-- Producer computes the dominant artist from the last 50 tracks, fetches Top-10 tracks for the market.
-- Publishes snapshot to `avd_artist_market_top_tracks`.
-
-### 4) Streamlit dashboard
-- Module: **`src/app/streamlit_app.py`**.
-- Pages: Recent plays, Top artists, Top tracks, latest Top-10 docs.
+4) (Optional) Add a Streamlit tab under `src/app/tabs/<prefix>.py` exposing `render(db, cfg, prefix)`.
 
 ---
 
-## Key files
+## Open items / next steps
 
-- `src/producers/avd_producer.py` — Spotify producer
-- `src/consumers/kafka_consumer.py` — Kafka → Mongo consumer
-- `src/lib/spotify_payloads.py` — Payload dataclasses & builders
-- `src/lib/kafka_producer.py` — Kafka helper
-- `src/app/streamlit_app.py` — Streamlit dashboard
-- `src/makefile` — Makefile (run & infra targets)
-- `src/docker-compose.yml` — Infrastructure (ZK, Kafka, Mongo, Mongo-Express)
+- Add a minimal **Generic Collections Explorer** tab that lists collections by `GENERIC_COLL_NAMESPACE` and shows last N docs.
+- Optional Spark Structured Streaming job for real‑time aggregates per user/topic.
+- CI guardrails: detect committed `.env` accidentally; run `flake8` / `ruff` on PRs.
 
 ---
 
-## Topics & collections
+## Changelog (most recent first)
 
-| Layer  | Name                               | Purpose                                    |
-|--------|------------------------------------|--------------------------------------------|
-| Kafka  | `avd_spotify_recent_events`        | Per-play events                             |
-| Kafka  | `avd_artist_market_top_tracks`     | Top-10 snapshot (dominant artist / market) |
-| Mongo  | `avd_recent_events`                | Append-only (unique `(user, track, played)`) |
-| Mongo  | `avd_artist_market_top_tracks`     | One doc per `(user, artist, market)`       |
-
----
-
-## Recent changes
-
-- Refactored to package structure: producer in `producers/`, consumer in `consumers/`, helpers in `lib/`.
-- Module entry points: run with `python -m producers.avd_producer` / `python -m consumers.kafka_consumer`.
-- Makefile simplified: only core targets (`run`, `consume`, `app`, `up`, `down`, `kafka-init`, `kafka-list`).
-- Documentation updated to match paths and defaults. Topic and collection names unchanged.
-
----
-
-## Next steps
-
-- Extend Streamlit with filters (market, date range) and separate tabs per teammate.
-- Allow additional producers under `src/producers/` with personal prefixes.
-- Optional: add Spark Structured Streaming for real-time aggregates.
+- **Generic multi‑user refactor**
+  - New env schema in `src/.env.example` with detailed comments.
+  - `make run-%` / `kafka-init-from-env` / generic tail/produce/delete targets.
+  - `app/tabs/avd.py` hardened (normalization, daily/market charts, extra insights, better caching).
+  - Backward compatibility for AVD topics kept.
+- Previous: initial single‑user pipeline (Spotify→Kafka→Mongo) + simple Streamlit dashboard.


### PR DESCRIPTION
- New env-driven workflow documented (APP_PREFIX, KAFKA_TOPICS, KAFKA_TOPIC_ROUTES, GENERIC_COLL_NAMESPACE, PRODUCER_ENTRY)
- How to run consumer/producer and Streamlit per teammate
- Kafka generic make targets and troubleshooting
- Current status + next steps