### PR TITLE
Add Spark Structured Streaming job and Makefile integration

### DIFF
--- a/src/.env-orig
+++ b/src/.env-orig
@@ -1,0 +1,59 @@
+# =========================
+# App identity
+# =========================
+APP_PREFIX=avd
+
+# =========================
+# Spotify API (your real creds go here)
+# =========================
+CLIENT_ID=5ec8fa1fa37e498082582a23212724ca
+CLIENT_SECRET=5684ac189992491e9df9d90c9ee3592e
+USERNAME=31fbaymkqi7ugbop2dhwywwjpmya
+REDIRECT_URI=http://127.0.0.1:8888/callback
+
+# Optional market override for "dominant artist" top10 (e.g., RO, AT, DE). Leave blank to use Spotify default.
+MARKET_OVERRIDE=UA
+
+# Spotipy env names (some libs expect these). Keep them in sync with the above.
+SPOTIPY_CLIENT_ID=5ec8fa1fa37e498082582a23212724ca
+SPOTIPY_CLIENT_SECRET=5684ac189992491e9df9d90c9ee3592e
+SPOTIPY_REDIRECT_URI=http://127.0.0.1:8888/callback
+# SPOTIPY_USERNAME=<optional>
+
+# =========================
+# Debug flags
+# =========================
+DEBUG=true
+KAFKA_ENABLED=true
+
+# =========================
+# Kafka cluster
+# =========================
+KAFKA_BOOTSTRAP=localhost:9092
+
+# List of ALL topics the consumer should subscribe to (yours + colleagues’)
+KAFKA_TOPICS=avd_recent_events,avd_artist_market_top_tracks
+
+# Optional routing: topic -> semantic handler ("events" | "top10")
+# Topics not listed here will be stored RAW into generic collections.
+KAFKA_TOPIC_ROUTES=avd_recent_events:events,avd_artist_market_top_tracks:top10
+
+# =========================
+# MongoDB
+# =========================
+MONGO_URL=mongodb://root:example@localhost:27017/?authSource=admin
+MONGO_DB=spotify_db
+
+# Dedicated collections for your pipeline (optional; Streamlit shows sections only if set)
+MONGO_COLL_EVENTS=avd_recent_events
+MONGO_COLL_TOP10=avd_artist_market_top_tracks
+
+# Namespace prefix for generic (raw) collections derived from topic names.
+# Example: topic "alex_clicks" becomes collection "avd__topic__alex_clicks".
+GENERIC_COLL_NAMESPACE=avd__topic__
+
+# =========================
+# Producer entrypoint (which producer file to run on `make run`)
+# =========================
+PRODUCER_ENTRY=src/producers/avd_producer.py
+

--- a/src/.env.example
+++ b/src/.env.example
@@ -85,3 +85,15 @@ GENERIC_COLL_NAMESPACE=alex__topic__
 # Example: src/producers/alex_producer.py or src/producers/vadim_producer.py
 PRODUCER_ENTRY=src/producers/alex_producer.py
 
+# =========================
+# Spark Streaming (per-topic schemas + RAW fallback)
+# =========================
+# If empty, Spark will reuse KAFKA_TOPICS
+SPARK_KAFKA_TOPICS=
+SPARK_TRIGGER_SECS=10
+SPARK_WATERMARK_MIN=5
+
+# Where Spark writes in Mongo (defaults are safe)
+SPARK_COLL_EVENTS=
+SPARK_COLL_RAW=
+

--- a/src/app/tabs/raw.py
+++ b/src/app/tabs/raw.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Generic RAW viewer tab for orchestrator.
+Shows documents stored by the Spark RAW fallback (<prefix>_raw_stream).
+"""
+
+import os
+import json
+import pandas as pd
+import streamlit as st
+from datetime import datetime, timezone
+
+@st.cache_data(show_spinner=False, ttl=30)
+def _load_raw(coll_name: str, limit: int = 500) -> pd.DataFrame:
+	db = st.session_state._orchestrator_mongo_db
+	cur = db[coll_name].find({}, {"_id": 0}).sort("ingest_ts", -1).limit(int(limit))
+	df = pd.DataFrame(list(cur))
+	if not df.empty and "raw_json" in df.columns:
+		# Try to pretty-print a preview column
+		df["raw_preview"] = df["raw_json"].apply(lambda s: s[:200] + "..." if isinstance(s, str) and len(s) > 200 else s)
+	return df
+
+def render(db, cfg, prefix: str) -> None:
+	st.session_state._orchestrator_mongo_db = db
+
+	raw_coll = os.getenv("SPARK_COLL_RAW", f"{prefix}_raw_stream")
+	st.caption(f"RAW collection: `{raw_coll}`")
+
+	df = _load_raw(raw_coll, limit=1000)
+	if df.empty:
+		st.info("No RAW documents yet.")
+		return
+
+	if "ingest_ts" in df.columns:
+		st.dataframe(df.sort_values("ingest_ts", ascending=False), use_container_width=True)
+	else:
+		st.dataframe(df, use_container_width=True)
+

--- a/src/app/team_config.yaml
+++ b/src/app/team_config.yaml
@@ -7,10 +7,12 @@ team:
     display_name: "Steshkov Vadim"
   - prefix: alex
     display_name: "Manzl Alexander"
+  - prefix: raw
+    display_name: Generic RAW
 
 defaults:
   mongo_url: "mongodb://root:example@localhost:27017/?authSource=admin"
   db_name: "spotify_db"
 
 ui:
-  tabs_order: ["Overview", "dorin", "gilian", "vadim", "alex"]
+  tabs_order: ["Overview", "dorin", "gilian", "vadim", "alex", "Generic RAW"]

--- a/src/makefile
+++ b/src/makefile
@@ -2,13 +2,24 @@
 # Variables
 # ===========
 PY := .venv/bin/python3
-KAFKA_CONTAINER ?= kafka
-BROKER_INTERNAL ?= kafka:19092    # inside Kafka container (used from docker exec)
-BROKER_EXTERNAL ?= localhost:9092 # from host (manual tools)
 
-# AVD topics (Dorin) — kept for backward compatibility
+# Containers in docker-compose.yml
+KAFKA_CONTAINER ?= kafka
+MONGO_CONTAINER ?= mongo
+
+# Kafka brokers
+BROKER_INTERNAL ?= kafka:19092    # used from inside containers (docker exec)
+BROKER_EXTERNAL ?= localhost:9092 # used from host tools
+
+# AVD Kafka topics (Dorin) — kept for backward compatibility
 TOPIC_EVENTS ?= avd_recent_events
 TOPIC_TOP10  ?= avd_artist_market_top_tracks
+
+# Default Spark packages (can be overridden via environment/.env)
+export SPARK_PACKAGES ?= org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1,org.apache.kafka:kafka-clients:3.5.2
+
+# Allow 'python -m' imports from current folder
+export PYTHONPATH := $(shell pwd)
 
 # ===========
 # Phony
@@ -18,7 +29,17 @@ TOPIC_TOP10  ?= avd_artist_market_top_tracks
 	kafka-tail kafka-tail-topic kafka-event kafka-event-topic \
 	kafka-delete-avd kafka-delete-topic \
 	run-avd run-% consume app \
-	env-avd env-alex env-vadim
+	env-avd env-alex env-vadim \
+	spark-run
+
+# ===========
+# Spark (Structured Streaming)
+# ===========
+spark-run:
+	$(PY) -m pip install -r spark/requirements.txt
+	PYSPARK_SUBMIT_ARGS="--packages $(SPARK_PACKAGES) pyspark-shell" \
+	$(PY) -m spark.streaming_job
+
 
 # ===========
 # Docker stack

--- a/src/spark/__init__.py
+++ b/src/spark/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""
+Make 'spark' a proper Python package so we can import:
+	from spark import schemas
+	from spark import streaming_job
+"""
+

--- a/src/spark/requirements.txt
+++ b/src/spark/requirements.txt
@@ -1,0 +1,4 @@
+pyspark>=3.5.0,<4.0
+pymongo>=4.6
+python-dotenv>=1.0
+

--- a/src/spark/schemas.py
+++ b/src/spark/schemas.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+Schema registry for per-topic parsing in Spark.
+- Each teammate can register a StructType for their topic.
+- Topics not in SCHEMAS will be ingested as RAW JSON (fallback).
+"""
+
+from pyspark.sql.types import (
+	StructType, StructField, StringType, ArrayType, LongType
+)
+
+# === Example: Dorin/AVD events (baseline you already use) ===
+AVD_EVENT_SCHEMA = StructType([
+	StructField("user_id", StringType()),
+	StructField("played_at", StringType()),
+	StructField("track_id", StringType()),
+	StructField("track_name", StringType()),
+	StructField("artist_ids", ArrayType(StringType())),
+	StructField("artist_names", ArrayType(StringType())),
+	StructField("album_id", StringType()),
+	StructField("album_name", StringType()),
+	StructField("country", StringType()),
+	StructField("market_used", StringType()),
+	StructField("track_duration_ms", LongType()),
+])
+
+# === Teammates add their schemas here (topic -> StructType) ===
+SCHEMAS = {
+	"avd_recent_events": AVD_EVENT_SCHEMA,	# example
+	# "alex_events": ALEX_EVENT_SCHEMA,
+	# "vadim_clicks": VADIM_EVENT_SCHEMA,
+}
+

--- a/src/spark/streaming_job.py
+++ b/src/spark/streaming_job.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Spark Structured Streaming job:
+	- Consumes JSON events from Kafka topics (from .env KAFKA_TOPICS / KAFKA_BOOTSTRAP)
+	- Parses flexible schema (handles artist_names as str|array|null, best-effort)
+	- Computes Top Artists by play count per micro-batch
+	- Writes aggregate to MongoDB (collection: <APP_PREFIX>_spark_leaderboard)
+	- Also prints aggregates to console for live demo
+
+Notes:
+	- No Mongo Spark connector needed; we use foreachBatch + PyMongo (simpler & portable)
+	- Safe on mixed/historic schemas; unknown fields are ignored
+"""
+
+import os
+from typing import List
+
+from dotenv import load_dotenv
+
+from pyspark.sql import SparkSession, DataFrame
+from pyspark.sql import functions as F
+from pyspark.sql.types import (
+	StructType, StructField, StringType, LongType, ArrayType
+)
+
+# ---------------------------
+# Load environment variables
+# ---------------------------
+load_dotenv()  # loads .env if present
+
+APP_PREFIX = os.getenv("APP_PREFIX", "avd").strip()
+KAFKA_BOOTSTRAP = os.getenv("KAFKA_BOOTSTRAP", "localhost:9092")
+KAFKA_TOPICS = os.getenv("KAFKA_TOPICS", "avd_recent_events")
+
+MONGO_URL = os.getenv("MONGO_URL", "mongodb://root:example@localhost:27017/?authSource=admin")
+MONGO_DB = os.getenv("MONGO_DB", "spotify_db")
+OUT_COLL = f"{APP_PREFIX}_spark_leaderboard"  # e.g., avd_spark_leaderboard
+
+# You can override this from the Makefile via PYSPARK_SUBMIT_ARGS,
+# but also inject it here so the job works when launched directly.
+SPARK_PACKAGES = os.getenv(
+	"SPARK_PACKAGES",
+	"org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1,org.apache.kafka:kafka-clients:3.5.2",
+)
+
+print(f"[Spark] bootstrap: {KAFKA_BOOTSTRAP}")
+print(f"[Spark] topics: {KAFKA_TOPICS.split(',')}")
+
+# ---------------------------
+# Spark session
+# ---------------------------
+spark = (
+	SparkSession.builder
+		.appName(f"{APP_PREFIX}_kafka_to_mongo_leaderboard")
+		.config("spark.sql.shuffle.partitions", "2")
+		.config("spark.jars.packages", SPARK_PACKAGES)  # <-- important
+		.getOrCreate()
+)
+# Lower Spark console noise; switch to "INFO" for debugging
+spark.sparkContext.setLogLevel("WARN")
+
+# ---------------------------
+# Kafka source
+# ---------------------------
+df_raw = (
+	spark.readStream
+		.format("kafka")
+		.option("kafka.bootstrap.servers", KAFKA_BOOTSTRAP)
+		.option("subscribe", KAFKA_TOPICS)  # comma-separated topics supported
+		.option("startingOffsets", "latest")
+		.load()
+)
+
+# Kafka value is binary; cast to string
+df_json_str = df_raw.select(
+	F.col("timestamp").alias("kafka_ts"),
+	F.col("value").cast("string").alias("raw_json")
+)
+
+# ---------------------------
+# Flexible schema for events
+# ---------------------------
+event_schema = StructType([
+	StructField("user_id", StringType(), True),
+	StructField("track_id", StringType(), True),
+	StructField("track_name", StringType(), True),
+	StructField("artist_ids", ArrayType(StringType()), True),   # may be list in newer docs
+	StructField("artist_names", ArrayType(StringType()), True), # may be list OR string in older docs
+	StructField("album_name", StringType(), True),
+	StructField("market_used", StringType(), True),
+	StructField("played_at", StringType(), True),
+	StructField("track_duration_ms", LongType(), True),
+])
+
+# Parse JSON with PERMISSIVE mode (malformed -> null)
+df_parsed = df_json_str.select(
+	F.from_json(F.col("raw_json"), event_schema, {"mode": "PERMISSIVE"}).alias("d"),
+	"kafka_ts",
+	"raw_json"
+).select("kafka_ts", "raw_json", "d.*")
+
+# ---------------------------
+# Robust normalization of artist_names:
+#	- if array<string> -> keep
+#	- if null but raw_json has a string at $.artist_names -> wrap as array
+#	- else -> empty array
+# ---------------------------
+# Best-effort fallback: pull raw field as string (when producers sent a scalar)
+raw_artist_names_str = F.get_json_object(F.col("raw_json"), "$.artist_names")
+
+df_norm = (
+	df_parsed
+		.withColumn(
+			"artist_names_norm",
+			F.when(F.col("artist_names").isNotNull(), F.col("artist_names"))
+			 .when(raw_artist_names_str.isNotNull(), F.array(raw_artist_names_str.cast("string")))
+			 .otherwise(F.array().cast("array<string>"))
+		)
+)
+
+# ---------------------------
+# Aggregation (Top Artists by plays) per micro-batch
+# ---------------------------
+df_exploded = df_norm.select(F.explode("artist_names_norm").alias("artist_name"))
+
+df_top = (
+	df_exploded
+		.groupBy("artist_name")
+		.agg(F.count(F.lit(1)).alias("plays"))
+		.orderBy(F.col("plays").desc())
+		.limit(10)
+		.withColumn("batch_ts", F.current_timestamp())
+		.select("batch_ts", "artist_name", "plays")
+)
+
+# ---------------------------
+# Mongo sink via foreachBatch (PyMongo)
+# ---------------------------
+def write_batch_to_mongo(batch_df: DataFrame, batch_id: int) -> None:
+	"""
+	Called for every micro-batch.
+	Writes the Top-10 rows to MongoDB as documents:
+	{ batch_ts, artist_name, plays, batch_id, prefix }
+	"""
+	import pymongo
+	from pymongo import MongoClient
+
+	rows: List[dict] = [row.asDict(recursive=True) for row in batch_df.collect()]
+	if not rows:
+		return
+
+	client = MongoClient(MONGO_URL)
+	try:
+		coll = client[MONGO_DB][OUT_COLL]
+		for r in rows:
+			r["batch_id"] = batch_id
+			r["prefix"] = APP_PREFIX
+		coll.insert_many(rows, ordered=False)
+	finally:
+		client.close()
+
+# ---------------------------
+# Dual sink: console + Mongo
+# ---------------------------
+query_console = (
+	df_top.writeStream
+		.outputMode("complete")  # print whole Top-10 each time
+		.format("console")
+		.option("truncate", "false")
+		.option("numRows", "20")
+		.start()
+)
+
+query_mongo = (
+	df_top.writeStream
+		.outputMode("complete")
+		.foreachBatch(write_batch_to_mongo)
+		.option("checkpointLocation", f"/tmp/{APP_PREFIX}_spark_leaderboard_ck")
+		.start()
+)
+
+# Wait for both streams
+query_console.awaitTermination()
+query_mongo.awaitTermination()
+


### PR DESCRIPTION
- Added src/spark/streaming_job.py with flexible schema & MongoDB sink
- Integrated Spark launcher (make spark-run) with PySpark + Kafka packages
- Updated .env.example for Spark compatibility (bootstrap, topics, Mongo URL)
- Adjusted team_config.yaml for multi-source Mongo (future Streamlit tab)
- Added raw.py placeholder tab for potential Spark leaderboard visualization
- Prepared groundwork for avd_spark_leaderboard collection in MongoDB