### PR TITLE
AVD: unify tab, add Spark view, Dockerized Spark, and Docker helpers

### DIFF
--- a/src/app/tabs/avd.py
+++ b/src/app/tabs/avd.py
@@ -1,447 +1,55 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
 """
-Runs as a plugin inside the orchestrator (db handle is injected by the parent app).
-
-Expose a single entrypoint:
-	render(db, cfg, prefix) -> None
-
-This tab focuses on:
-- recent plays (with robust schema handling)
-- daily plays in selected period
-- plays per market
-- top artists / top tracks
-- latest "dominant artist per market" Top-10 docs
-- extra insights (weekday/hour distributions, avg duration, most played album)
+AVD tab wrapper:
+- Keeps your existing Streamlit dashboard 100% intact (moved to avd_classic.py)
+- Adds a second sub-tab that shows Spark results (auto-discovered avd_spark_* collections)
+- Orchestrator still imports app.tabs.avd:render(db, cfg, prefix)
 """
 
-import os
-from datetime import datetime, timezone, date, time
-from typing import Tuple, List, Optional
-
-import pandas as pd
 import streamlit as st
-import altair as alt
-from pymongo.errors import PyMongoError
 
-# =========================
-# Helpers (prefix-based collections)
-# =========================
-def _coll_names(prefix: str) -> Tuple[str, str]:
-	"""Return (events_collection, top10_collection) for a given prefix.
+# Import your current dashboard as "classic"
+try:
+	from app.tabs import avd_classic as classic_tab
+except Exception as e:
+	classic_tab = None
 
-	By convention:
-		<prefix>_recent_events
-		<prefix>_artist_market_top_tracks
+# Generic Spark renderer (shows all <prefix>_spark_* collections)
+try:
+	from app.tabs import spark_generic as spark_tab
+except Exception as e:
+	spark_tab = None
 
-	Explicit overrides:
-		- COLL_EVENTS, COLL_TOP10 (env) — mainly for local experiments
+
+def render(db, cfg, prefix: str = "avd"):
 	"""
-	coll_events = f"{prefix}_recent_events"
-	coll_top10 = f"{prefix}_artist_market_top_tracks"
-
-	coll_events = os.getenv("COLL_EVENTS", coll_events)
-	coll_top10 = os.getenv("COLL_TOP10", coll_top10)
-	return coll_events, coll_top10
-
-
-def _utc_range(d_from: date, d_to: date) -> Tuple[datetime, datetime]:
-	"""Convert two date objects to a full-day UTC datetime interval."""
-	start = datetime.combine(d_from, time.min, tzinfo=timezone.utc)
-	end = datetime.combine(d_to, time.max, tzinfo=timezone.utc)
-	return start, end
-
-
-# =========================
-# Normalization stage(s)
-# =========================
-# Make artist_ids / artist_names arrays, even when older docs stored a string/null.
-PIPE_NORMALIZE_ARTISTS = [
-	{
-		"$set": {
-			"artist_ids_norm": {
-				"$cond": [
-					{"$isArray": "$artist_ids"},
-					"$artist_ids",
-					{"$cond": [{"$eq": ["$artist_ids", None]}, [], ["$artist_ids"]]},
-				]
-			},
-			"artist_names_norm": {
-				"$cond": [
-					{"$isArray": "$artist_names"},
-					"$artist_names",
-					{"$cond": [{"$eq": ["$artist_names", None]}, [], ["$artist_names"]]},
-				]
-			},
-		}
-	}
-]
-
-
-# =========================
-# Data loaders / computations (cached)
-# =========================
-@st.cache_data(show_spinner=False, ttl=60)
-def _load_recent_events(coll_name: str, d_from: str, d_to: str, limit: int) -> pd.DataFrame:
-	"""Load recent events with safe projection; attach parsed datetime for UI.
-
-	Relies on:
-		st.session_state._orchestrator_mongo_db  (set in render())
+	Entry point used by the orchestrator.
+	Builds two sub-tabs:
+	- Classic: your original AVD dashboard (from avd_classic.py)
+	- Spark:   generic Spark collections for <prefix>_spark_*
 	"""
-	try:
-		db = st.session_state._orchestrator_mongo_db
-		q = {"played_at": {"$gte": d_from, "$lte": d_to}} if (d_from and d_to) else {}
-		cur = db[coll_name].find(
-			q,
-			{
-				"_id": 0,
-				"user_id": 1,
-				"played_at": 1,
-				"track_id": 1,
-				"track_name": 1,
-				"artist_ids": 1,
-				"artist_names": 1,
-				"album_id": 1,
-				"album_name": 1,
-				"country": 1,
-				"market_used": 1,
-				"track_duration_ms": 1,
-			},
-		).sort("played_at", -1).limit(int(limit))
-		df = pd.DataFrame(list(cur))
-		if not df.empty:
-			df["played_at_dt"] = pd.to_datetime(df["played_at"], utc=True, errors="coerce")
-		return df
-	except PyMongoError as e:
-		st.error(f"Mongo error while loading events from {coll_name}: {e}")
-		return pd.DataFrame()
+	st.title("🎧 AVD — Unified Dashboard")
+	tab_classic, tab_spark = st.tabs(["Classic", "Spark"])
 
-
-@st.cache_data(show_spinner=False, ttl=60)
-def _top_artists(coll_name: str, d_from: str, d_to: str, limit: int) -> pd.DataFrame:
-	"""Compute top artists by play count, robust to mixed schemas."""
-	try:
-		db = st.session_state._orchestrator_mongo_db
-		match = {"played_at": {"$gte": d_from, "$lte": d_to}} if (d_from and d_to) else {}
-
-		pipeline: List[dict] = []
-		pipeline += PIPE_NORMALIZE_ARTISTS
-		pipeline.append({"$match": match} if match else {"$match": {}})
-		pipeline += [
-			{"$unwind": "$artist_ids_norm"},
-			{"$group": {"_id": "$artist_ids_norm", "plays": {"$sum": 1}}},
-			{"$sort": {"plays": -1}},
-			{"$limit": int(limit)},
-
-			# Try to recover a display name for each artist id
-			{
-				"$lookup": {
-					"from": coll_name,
-					"localField": "_id",
-					"foreignField": "artist_ids",
-					"as": "sample_docs",
-				}
-			},
-			{
-				"$set": {
-					"artist_name": {
-						"$let": {
-							"vars": {"first": {"$first": "$sample_docs"}},
-							"in": {
-								"$cond": [
-									{"$gt": [{"$size": {"$ifNull": ["$$first.artist_names", []]}}, 0]},
-									{"$arrayElemAt": ["$$first.artist_names", 0]},
-									"Unknown",
-								]
-							},
-						}
-					}
-				}
-			},
-			{"$project": {"_id": 0, "artist_id": "$_id", "artist_name": 1, "plays": 1}},
-		]
-
-		rows = list(db[coll_name].aggregate(pipeline))
-		return pd.DataFrame(rows)
-	except PyMongoError as e:
-		st.error(f"Mongo error while computing top artists from {coll_name}: {e}")
-		return pd.DataFrame()
-
-
-@st.cache_data(show_spinner=False, ttl=60)
-def _top_tracks(coll_name: str, d_from: str, d_to: str, limit: int) -> pd.DataFrame:
-	"""Compute top tracks by play count (group by track_id & track_name)."""
-	try:
-		db = st.session_state._orchestrator_mongo_db
-		match = {"played_at": {"$gte": d_from, "$lte": d_to}} if (d_from and d_to) else {}
-		pipeline = [
-			{"$match": match} if match else {"$match": {}},
-			{
-				"$group": {
-					"_id": {"track_id": "$track_id", "track_name": "$track_name"},
-					"plays": {"$sum": 1},
-					"any_artist_names": {"$first": "$artist_names"},
-				}
-			},
-			{"$sort": {"plays": -1}},
-			{"$limit": int(limit)},
-		]
-		df = pd.DataFrame(list(db[coll_name].aggregate(pipeline)))
-		if not df.empty:
-			df["track_id"] = df["_id"].apply(lambda x: (x or {}).get("track_id"))
-			df["track_name"] = df["_id"].apply(lambda x: (x or {}).get("track_name"))
-			df.drop(columns=["_id"], inplace=True, errors="ignore")
-		return df
-	except PyMongoError as e:
-		st.error(f"Mongo error while computing top tracks from {coll_name}: {e}")
-		return pd.DataFrame()
-
-
-@st.cache_data(show_spinner=False, ttl=60)
-def _latest_top10_docs(coll_name: str, limit: int) -> pd.DataFrame:
-	"""Load the latest generated 'Top 10 for dominant artist' documents."""
-	try:
-		db = st.session_state._orchestrator_mongo_db
-		cur = db[coll_name].find({}, {"_id": 0}).sort("generated_at", -1).limit(int(limit))
-		return pd.DataFrame(list(cur))
-	except PyMongoError as e:
-		st.error(f"Mongo error while loading top10 docs from {coll_name}: {e}")
-		return pd.DataFrame()
-
-
-# =========================
-# Main render (tab)
-# =========================
-def render(db, cfg, prefix: str) -> None:
-	"""
-	Render a tab for the given prefix.
-	- Uses its own filters (date range, limits)
-	- Shows: daily plays, plays per market, recent plays, extra insights,
-	         top artists, top tracks, latest Top-10 docs
-	"""
-	# Expose db handle to cached functions (avoid reconnects)
-	st.session_state._orchestrator_mongo_db = db
-
-	coll_events, coll_top10 = _coll_names(prefix)
-
-	# ---------- Filters (tab-level) ----------
-	with st.sidebar:
-		st.markdown(f"**[{prefix}]** Collections: `{coll_events}`, `{coll_top10}`")
-
-	utc_now = datetime.now(timezone.utc)
-	default_from = utc_now.replace(hour=0, minute=0, second=0, microsecond=0)
-
-	col_f1, col_f2, col_f3 = st.columns([1, 1, 1])
-	with col_f1:
-		date_from = st.date_input("From (UTC date)", default_from.date(), key=f"{prefix}_from")
-	with col_f2:
-		date_to = st.date_input("To (UTC date)", utc_now.date(), key=f"{prefix}_to")
-	with col_f3:
-		top_k = st.slider("Top N items (Artists or Tracks)", min_value=5, max_value=50, value=10, step=5, key=f"{prefix}_topk")
-
-	show_limit = st.selectbox(
-		"Recent plays limit",
-		options=[100, 250, 500, 1000, 5000, 10000],
-		index=4,
-		key=f"{prefix}_limit",
-	)
-
-	start_dt, end_dt = _utc_range(date_from, date_to)
-	start_iso, end_iso = start_dt.isoformat(), end_dt.isoformat()
-
-	# ---------- Daily plays ----------
-	st.subheader("Daily plays (selected range)")
-	pipeline_daily = [
-		{"$match": {"played_at": {"$gte": start_iso, "$lte": end_iso}}},
-		{
-			"$group": {
-				"_id": {"$substr": ["$played_at", 0, 10]},  # YYYY-MM-DD
-				"plays": {"$sum": 1},
-			}
-		},
-		{"$sort": {"_id": 1}},
-	]
-	try:
-		rows_daily = list(db[coll_events].aggregate(pipeline_daily))
-		df_daily = pd.DataFrame(rows_daily)
-		if not df_daily.empty:
-			df_daily.rename(columns={"_id": "date"}, inplace=True)
-			st.line_chart(df_daily.set_index("date")["plays"])
-			st.dataframe(df_daily, use_container_width=True)
+	# -------- Classic (your existing code) --------
+	with tab_classic:
+		st.caption("Your original dashboard (unchanged).")
+		if classic_tab and hasattr(classic_tab, "render"):
+			# Call your existing render exactly as before
+			classic_tab.render(db=db, cfg=cfg, prefix=prefix)
 		else:
-			st.info("No data in the selected date range.")
-	except PyMongoError as e:
-		st.error(f"Mongo error while computing daily plays: {e}")
+			st.error("Could not load avd_classic.render(). Make sure src/app/tabs/avd_classic.py exists.")
 
-	# ---------- Plays per market ----------
-	st.subheader("Plays per market")
-	pipeline_market = [
-		{"$match": {"played_at": {"$gte": start_iso, "$lte": end_iso}}},
-		{"$group": {"_id": "$market_used", "plays": {"$sum": 1}}},
-		{"$sort": {"plays": -1}},
-	]
-	try:
-		rows_market = list(db[coll_events].aggregate(pipeline_market))
-		df_market = pd.DataFrame(rows_market)
-		if not df_market.empty:
-			df_market.rename(columns={"_id": "market"}, inplace=True)
-			st.bar_chart(df_market.set_index("market")["plays"])
-			# Optional pie chart with Altair
-			chart = alt.Chart(df_market).mark_arc().encode(
-				theta="plays",
-				color="market",
-				tooltip=["market", "plays"],
-			)
-			st.altair_chart(chart, use_container_width=True)
-			st.dataframe(df_market, use_container_width=True)
+	# -------- Spark (generic) --------
+	with tab_spark:
+		st.caption(f"Spark analytics for collections like `{prefix}_spark_*`.")
+		if spark_tab and hasattr(spark_tab, "render"):
+			try:
+				spark_tab.render(db=db, cfg=cfg, prefix=prefix)
+			except Exception as e:
+				st.error(f"Spark tab failed: {e}")
 		else:
-			st.info("No market data in the selected range.")
-	except PyMongoError as e:
-		st.error(f"Mongo error while computing plays per market: {e}")
-
-	# ---------- Recent plays ----------
-	st.subheader("Recent plays")
-	df_recent = _load_recent_events(coll_events, start_iso, end_iso, int(show_limit))
-	st.caption(f"{len(df_recent)} rows")
-	if df_recent.empty:
-		st.info(f"No data found in {coll_events} for the selected range.")
-	else:
-		st.dataframe(
-			df_recent[["played_at_dt", "track_name", "artist_names", "album_name", "market_used", "track_duration_ms"]]
-				.rename(columns={"played_at_dt": "played_at"}),
-			use_container_width=True,
-		)
-
-	# ---------- Extra insights ----------
-	st.subheader("Extra insights")
-	if not df_recent.empty:
-		# Weekly listening pattern (Mon..Sun)
-		try:
-			df_recent["weekday"] = df_recent["played_at_dt"].dt.day_name()
-			order = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-			weekday_counts = df_recent["weekday"].value_counts().reindex(order).fillna(0).astype(int)
-			st.markdown("**Weekly listening pattern**")
-			st.bar_chart(weekday_counts)
-		except Exception:
-			st.info("Could not compute weekly listening pattern.")
-
-		# Listening by hour of day (0..23)
-		try:
-			df_recent["hour"] = df_recent["played_at_dt"].dt.hour
-			hour_counts = df_recent["hour"].value_counts().sort_index()
-			st.markdown("**Listening by hour of day**")
-			st.bar_chart(hour_counts)
-		except Exception:
-			st.info("Could not compute hourly distribution.")
-
-		# Average track duration (minutes)
-		try:
-			if "track_duration_ms" in df_recent.columns and df_recent["track_duration_ms"].notna().any():
-				avg_duration_min = df_recent["track_duration_ms"].dropna().mean() / 60000.0
-				st.metric("Average track duration (min)", f"{avg_duration_min:.2f}")
-		except Exception:
-			pass
-
-		# Most played album
-		try:
-			if "album_name" in df_recent.columns and df_recent["album_name"].notna().any():
-				top_album = df_recent["album_name"].value_counts().idxmax()
-				st.metric("Most played album", top_album)
-		except Exception:
-			pass
-	else:
-		st.info("No extra insights available without recent data.")
-
-	# ---------- Side-by-side: Top artists / Top tracks ----------
-	col1, col2 = st.columns(2, gap="large")
-
-	with col1:
-		st.subheader("Top artists (by plays)")
-		df_art = _top_artists(coll_events, start_iso, end_iso, int(top_k))
-		if df_art.empty:
-			st.info("No artist data found.")
-		else:
-			df_art["label"] = df_art["artist_name"].fillna(df_art["artist_id"])
-			st.bar_chart(df_art.set_index("label")["plays"])
-			st.dataframe(df_art[["artist_id", "artist_name", "plays"]], use_container_width=True)
-
-	with col2:
-		st.subheader("Top tracks (by plays)")
-		df_tr = _top_tracks(coll_events, start_iso, end_iso, int(top_k))
-		if df_tr.empty:
-			st.info("No track data found.")
-		else:
-			df_tr["label"] = df_tr["track_name"].fillna(df_tr["track_id"])
-			st.bar_chart(df_tr.set_index("label")["plays"])
-			st.dataframe(
-				df_tr[["track_id", "track_name", "any_artist_names", "plays"]]
-					.rename(columns={"any_artist_names": "artist_names"}),
-				use_container_width=True,
-			)
-
-	# ---------- Latest Top-10 docs ----------
-	st.subheader("Latest ‘Top 10 for dominant artist in market’ docs")
-	df_top10 = _latest_top10_docs(coll_top10, limit=10)
-	if df_top10.empty:
-		st.info(f"No documents in {coll_top10} yet.")
-	else:
-		cols = ["generated_at", "market", "artist_name", "artist_id", "user_id"]
-		existing_cols = [c for c in cols if c in df_top10.columns]
-		if existing_cols:
-			st.dataframe(df_top10[existing_cols], use_container_width=True)
-		else:
-			st.dataframe(df_top10, use_container_width=True)
-
-		for _, row in df_top10.iterrows():
-			title = f"{row.get('artist_name','?')} · {row.get('market','?')} · {row.get('generated_at','?')}"
-			with st.expander(title):
-				tracks = pd.DataFrame(row.get("tracks") or [])
-				if not tracks.empty:
-					show_cols = [c for c in ["rank", "track_name", "duration_ms", "album_name", "artists"] if c in tracks.columns]
-					if "rank" in show_cols:
-						st.dataframe(tracks[show_cols].set_index("rank"), use_container_width=True)
-					else:
-						st.dataframe(tracks[show_cols], use_container_width=True)
-				else:
-					st.write("No tracks array.")
-
-	# ---------- Unique artists & tracks ----------
-	try:
-		# Unique tracks by track_id
-		unique_tracks = df_recent["track_id"].nunique(dropna=True) if "track_id" in df_recent.columns else 0
-
-		# Unique artists by flattening artist_ids (handles list/str/None)
-		def _to_list(v):
-			if isinstance(v, list):
-				return v
-			if v is None:
-				return []
-			return [v]
-
-		unique_artist_ids = set()
-		if "artist_ids" in df_recent.columns and df_recent["artist_ids"].notna().any():
-			for v in df_recent["artist_ids"].dropna():
-				for a in _to_list(v):
-					unique_artist_ids.add(a)
-		unique_artists = len(unique_artist_ids)
-
-		c1, c2 = st.columns(2)
-		with c1:
-			st.markdown(
-				f"<div style='text-align:center'>"
-				f"<span style='font-size:18px; color:gray'>Unique artists</span><br>"
-				f"<span style='font-size:32px; font-weight:bold'>{unique_artists}</span>"
-				f"</div>",
-				unsafe_allow_html=True,
-			)
-
-		with c2:
-			st.markdown(
-				f"<div style='text-align:center'>"
-				f"<span style='font-size:18px; color:gray'>Unique tracks</span><br>"
-				f"<span style='font-size:32px; font-weight:bold'>{unique_tracks}</span>"
-				f"</div>",
-				unsafe_allow_html=True,
-			)
-	except Exception:
-		st.info("Could not compute unique artists/tracks.")
+			st.info("spark_generic tab not found. Add src/app/tabs/spark_generic.py to enable this view.")
 

--- a/src/app/tabs/avd_classic.py
+++ b/src/app/tabs/avd_classic.py
@@ -1,0 +1,447 @@
+# -*- coding: utf-8 -*-
+"""
+Runs as a plugin inside the orchestrator (db handle is injected by the parent app).
+
+Expose a single entrypoint:
+	render(db, cfg, prefix) -> None
+
+This tab focuses on:
+- recent plays (with robust schema handling)
+- daily plays in selected period
+- plays per market
+- top artists / top tracks
+- latest "dominant artist per market" Top-10 docs
+- extra insights (weekday/hour distributions, avg duration, most played album)
+"""
+
+import os
+from datetime import datetime, timezone, date, time
+from typing import Tuple, List, Optional
+
+import pandas as pd
+import streamlit as st
+import altair as alt
+from pymongo.errors import PyMongoError
+
+# =========================
+# Helpers (prefix-based collections)
+# =========================
+def _coll_names(prefix: str) -> Tuple[str, str]:
+	"""Return (events_collection, top10_collection) for a given prefix.
+
+	By convention:
+		<prefix>_recent_events
+		<prefix>_artist_market_top_tracks
+
+	Explicit overrides:
+		- COLL_EVENTS, COLL_TOP10 (env) — mainly for local experiments
+	"""
+	coll_events = f"{prefix}_recent_events"
+	coll_top10 = f"{prefix}_artist_market_top_tracks"
+
+	coll_events = os.getenv("COLL_EVENTS", coll_events)
+	coll_top10 = os.getenv("COLL_TOP10", coll_top10)
+	return coll_events, coll_top10
+
+
+def _utc_range(d_from: date, d_to: date) -> Tuple[datetime, datetime]:
+	"""Convert two date objects to a full-day UTC datetime interval."""
+	start = datetime.combine(d_from, time.min, tzinfo=timezone.utc)
+	end = datetime.combine(d_to, time.max, tzinfo=timezone.utc)
+	return start, end
+
+
+# =========================
+# Normalization stage(s)
+# =========================
+# Make artist_ids / artist_names arrays, even when older docs stored a string/null.
+PIPE_NORMALIZE_ARTISTS = [
+	{
+		"$set": {
+			"artist_ids_norm": {
+				"$cond": [
+					{"$isArray": "$artist_ids"},
+					"$artist_ids",
+					{"$cond": [{"$eq": ["$artist_ids", None]}, [], ["$artist_ids"]]},
+				]
+			},
+			"artist_names_norm": {
+				"$cond": [
+					{"$isArray": "$artist_names"},
+					"$artist_names",
+					{"$cond": [{"$eq": ["$artist_names", None]}, [], ["$artist_names"]]},
+				]
+			},
+		}
+	}
+]
+
+
+# =========================
+# Data loaders / computations (cached)
+# =========================
+@st.cache_data(show_spinner=False, ttl=60)
+def _load_recent_events(coll_name: str, d_from: str, d_to: str, limit: int) -> pd.DataFrame:
+	"""Load recent events with safe projection; attach parsed datetime for UI.
+
+	Relies on:
+		st.session_state._orchestrator_mongo_db  (set in render())
+	"""
+	try:
+		db = st.session_state._orchestrator_mongo_db
+		q = {"played_at": {"$gte": d_from, "$lte": d_to}} if (d_from and d_to) else {}
+		cur = db[coll_name].find(
+			q,
+			{
+				"_id": 0,
+				"user_id": 1,
+				"played_at": 1,
+				"track_id": 1,
+				"track_name": 1,
+				"artist_ids": 1,
+				"artist_names": 1,
+				"album_id": 1,
+				"album_name": 1,
+				"country": 1,
+				"market_used": 1,
+				"track_duration_ms": 1,
+			},
+		).sort("played_at", -1).limit(int(limit))
+		df = pd.DataFrame(list(cur))
+		if not df.empty:
+			df["played_at_dt"] = pd.to_datetime(df["played_at"], utc=True, errors="coerce")
+		return df
+	except PyMongoError as e:
+		st.error(f"Mongo error while loading events from {coll_name}: {e}")
+		return pd.DataFrame()
+
+
+@st.cache_data(show_spinner=False, ttl=60)
+def _top_artists(coll_name: str, d_from: str, d_to: str, limit: int) -> pd.DataFrame:
+	"""Compute top artists by play count, robust to mixed schemas."""
+	try:
+		db = st.session_state._orchestrator_mongo_db
+		match = {"played_at": {"$gte": d_from, "$lte": d_to}} if (d_from and d_to) else {}
+
+		pipeline: List[dict] = []
+		pipeline += PIPE_NORMALIZE_ARTISTS
+		pipeline.append({"$match": match} if match else {"$match": {}})
+		pipeline += [
+			{"$unwind": "$artist_ids_norm"},
+			{"$group": {"_id": "$artist_ids_norm", "plays": {"$sum": 1}}},
+			{"$sort": {"plays": -1}},
+			{"$limit": int(limit)},
+
+			# Try to recover a display name for each artist id
+			{
+				"$lookup": {
+					"from": coll_name,
+					"localField": "_id",
+					"foreignField": "artist_ids",
+					"as": "sample_docs",
+				}
+			},
+			{
+				"$set": {
+					"artist_name": {
+						"$let": {
+							"vars": {"first": {"$first": "$sample_docs"}},
+							"in": {
+								"$cond": [
+									{"$gt": [{"$size": {"$ifNull": ["$$first.artist_names", []]}}, 0]},
+									{"$arrayElemAt": ["$$first.artist_names", 0]},
+									"Unknown",
+								]
+							},
+						}
+					}
+				}
+			},
+			{"$project": {"_id": 0, "artist_id": "$_id", "artist_name": 1, "plays": 1}},
+		]
+
+		rows = list(db[coll_name].aggregate(pipeline))
+		return pd.DataFrame(rows)
+	except PyMongoError as e:
+		st.error(f"Mongo error while computing top artists from {coll_name}: {e}")
+		return pd.DataFrame()
+
+
+@st.cache_data(show_spinner=False, ttl=60)
+def _top_tracks(coll_name: str, d_from: str, d_to: str, limit: int) -> pd.DataFrame:
+	"""Compute top tracks by play count (group by track_id & track_name)."""
+	try:
+		db = st.session_state._orchestrator_mongo_db
+		match = {"played_at": {"$gte": d_from, "$lte": d_to}} if (d_from and d_to) else {}
+		pipeline = [
+			{"$match": match} if match else {"$match": {}},
+			{
+				"$group": {
+					"_id": {"track_id": "$track_id", "track_name": "$track_name"},
+					"plays": {"$sum": 1},
+					"any_artist_names": {"$first": "$artist_names"},
+				}
+			},
+			{"$sort": {"plays": -1}},
+			{"$limit": int(limit)},
+		]
+		df = pd.DataFrame(list(db[coll_name].aggregate(pipeline)))
+		if not df.empty:
+			df["track_id"] = df["_id"].apply(lambda x: (x or {}).get("track_id"))
+			df["track_name"] = df["_id"].apply(lambda x: (x or {}).get("track_name"))
+			df.drop(columns=["_id"], inplace=True, errors="ignore")
+		return df
+	except PyMongoError as e:
+		st.error(f"Mongo error while computing top tracks from {coll_name}: {e}")
+		return pd.DataFrame()
+
+
+@st.cache_data(show_spinner=False, ttl=60)
+def _latest_top10_docs(coll_name: str, limit: int) -> pd.DataFrame:
+	"""Load the latest generated 'Top 10 for dominant artist' documents."""
+	try:
+		db = st.session_state._orchestrator_mongo_db
+		cur = db[coll_name].find({}, {"_id": 0}).sort("generated_at", -1).limit(int(limit))
+		return pd.DataFrame(list(cur))
+	except PyMongoError as e:
+		st.error(f"Mongo error while loading top10 docs from {coll_name}: {e}")
+		return pd.DataFrame()
+
+
+# =========================
+# Main render (tab)
+# =========================
+def render(db, cfg, prefix: str) -> None:
+	"""
+	Render a tab for the given prefix.
+	- Uses its own filters (date range, limits)
+	- Shows: daily plays, plays per market, recent plays, extra insights,
+	         top artists, top tracks, latest Top-10 docs
+	"""
+	# Expose db handle to cached functions (avoid reconnects)
+	st.session_state._orchestrator_mongo_db = db
+
+	coll_events, coll_top10 = _coll_names(prefix)
+
+	# ---------- Filters (tab-level) ----------
+	with st.sidebar:
+		st.markdown(f"**[{prefix}]** Collections: `{coll_events}`, `{coll_top10}`")
+
+	utc_now = datetime.now(timezone.utc)
+	default_from = utc_now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+	col_f1, col_f2, col_f3 = st.columns([1, 1, 1])
+	with col_f1:
+		date_from = st.date_input("From (UTC date)", default_from.date(), key=f"{prefix}_from")
+	with col_f2:
+		date_to = st.date_input("To (UTC date)", utc_now.date(), key=f"{prefix}_to")
+	with col_f3:
+		top_k = st.slider("Top N items (Artists or Tracks)", min_value=5, max_value=50, value=10, step=5, key=f"{prefix}_topk")
+
+	show_limit = st.selectbox(
+		"Recent plays limit",
+		options=[100, 250, 500, 1000, 5000, 10000],
+		index=4,
+		key=f"{prefix}_limit",
+	)
+
+	start_dt, end_dt = _utc_range(date_from, date_to)
+	start_iso, end_iso = start_dt.isoformat(), end_dt.isoformat()
+
+	# ---------- Daily plays ----------
+	st.subheader("Daily plays (selected range)")
+	pipeline_daily = [
+		{"$match": {"played_at": {"$gte": start_iso, "$lte": end_iso}}},
+		{
+			"$group": {
+				"_id": {"$substr": ["$played_at", 0, 10]},  # YYYY-MM-DD
+				"plays": {"$sum": 1},
+			}
+		},
+		{"$sort": {"_id": 1}},
+	]
+	try:
+		rows_daily = list(db[coll_events].aggregate(pipeline_daily))
+		df_daily = pd.DataFrame(rows_daily)
+		if not df_daily.empty:
+			df_daily.rename(columns={"_id": "date"}, inplace=True)
+			st.line_chart(df_daily.set_index("date")["plays"])
+			st.dataframe(df_daily, use_container_width=True)
+		else:
+			st.info("No data in the selected date range.")
+	except PyMongoError as e:
+		st.error(f"Mongo error while computing daily plays: {e}")
+
+	# ---------- Plays per market ----------
+	st.subheader("Plays per market")
+	pipeline_market = [
+		{"$match": {"played_at": {"$gte": start_iso, "$lte": end_iso}}},
+		{"$group": {"_id": "$market_used", "plays": {"$sum": 1}}},
+		{"$sort": {"plays": -1}},
+	]
+	try:
+		rows_market = list(db[coll_events].aggregate(pipeline_market))
+		df_market = pd.DataFrame(rows_market)
+		if not df_market.empty:
+			df_market.rename(columns={"_id": "market"}, inplace=True)
+			st.bar_chart(df_market.set_index("market")["plays"])
+			# Optional pie chart with Altair
+			chart = alt.Chart(df_market).mark_arc().encode(
+				theta="plays",
+				color="market",
+				tooltip=["market", "plays"],
+			)
+			st.altair_chart(chart, use_container_width=True)
+			st.dataframe(df_market, use_container_width=True)
+		else:
+			st.info("No market data in the selected range.")
+	except PyMongoError as e:
+		st.error(f"Mongo error while computing plays per market: {e}")
+
+	# ---------- Recent plays ----------
+	st.subheader("Recent plays")
+	df_recent = _load_recent_events(coll_events, start_iso, end_iso, int(show_limit))
+	st.caption(f"{len(df_recent)} rows")
+	if df_recent.empty:
+		st.info(f"No data found in {coll_events} for the selected range.")
+	else:
+		st.dataframe(
+			df_recent[["played_at_dt", "track_name", "artist_names", "album_name", "market_used", "track_duration_ms"]]
+				.rename(columns={"played_at_dt": "played_at"}),
+			use_container_width=True,
+		)
+
+	# ---------- Extra insights ----------
+	st.subheader("Extra insights")
+	if not df_recent.empty:
+		# Weekly listening pattern (Mon..Sun)
+		try:
+			df_recent["weekday"] = df_recent["played_at_dt"].dt.day_name()
+			order = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+			weekday_counts = df_recent["weekday"].value_counts().reindex(order).fillna(0).astype(int)
+			st.markdown("**Weekly listening pattern**")
+			st.bar_chart(weekday_counts)
+		except Exception:
+			st.info("Could not compute weekly listening pattern.")
+
+		# Listening by hour of day (0..23)
+		try:
+			df_recent["hour"] = df_recent["played_at_dt"].dt.hour
+			hour_counts = df_recent["hour"].value_counts().sort_index()
+			st.markdown("**Listening by hour of day**")
+			st.bar_chart(hour_counts)
+		except Exception:
+			st.info("Could not compute hourly distribution.")
+
+		# Average track duration (minutes)
+		try:
+			if "track_duration_ms" in df_recent.columns and df_recent["track_duration_ms"].notna().any():
+				avg_duration_min = df_recent["track_duration_ms"].dropna().mean() / 60000.0
+				st.metric("Average track duration (min)", f"{avg_duration_min:.2f}")
+		except Exception:
+			pass
+
+		# Most played album
+		try:
+			if "album_name" in df_recent.columns and df_recent["album_name"].notna().any():
+				top_album = df_recent["album_name"].value_counts().idxmax()
+				st.metric("Most played album", top_album)
+		except Exception:
+			pass
+	else:
+		st.info("No extra insights available without recent data.")
+
+	# ---------- Side-by-side: Top artists / Top tracks ----------
+	col1, col2 = st.columns(2, gap="large")
+
+	with col1:
+		st.subheader("Top artists (by plays)")
+		df_art = _top_artists(coll_events, start_iso, end_iso, int(top_k))
+		if df_art.empty:
+			st.info("No artist data found.")
+		else:
+			df_art["label"] = df_art["artist_name"].fillna(df_art["artist_id"])
+			st.bar_chart(df_art.set_index("label")["plays"])
+			st.dataframe(df_art[["artist_id", "artist_name", "plays"]], use_container_width=True)
+
+	with col2:
+		st.subheader("Top tracks (by plays)")
+		df_tr = _top_tracks(coll_events, start_iso, end_iso, int(top_k))
+		if df_tr.empty:
+			st.info("No track data found.")
+		else:
+			df_tr["label"] = df_tr["track_name"].fillna(df_tr["track_id"])
+			st.bar_chart(df_tr.set_index("label")["plays"])
+			st.dataframe(
+				df_tr[["track_id", "track_name", "any_artist_names", "plays"]]
+					.rename(columns={"any_artist_names": "artist_names"}),
+				use_container_width=True,
+			)
+
+	# ---------- Latest Top-10 docs ----------
+	st.subheader("Latest ‘Top 10 for dominant artist in market’ docs")
+	df_top10 = _latest_top10_docs(coll_top10, limit=10)
+	if df_top10.empty:
+		st.info(f"No documents in {coll_top10} yet.")
+	else:
+		cols = ["generated_at", "market", "artist_name", "artist_id", "user_id"]
+		existing_cols = [c for c in cols if c in df_top10.columns]
+		if existing_cols:
+			st.dataframe(df_top10[existing_cols], use_container_width=True)
+		else:
+			st.dataframe(df_top10, use_container_width=True)
+
+		for _, row in df_top10.iterrows():
+			title = f"{row.get('artist_name','?')} · {row.get('market','?')} · {row.get('generated_at','?')}"
+			with st.expander(title):
+				tracks = pd.DataFrame(row.get("tracks") or [])
+				if not tracks.empty:
+					show_cols = [c for c in ["rank", "track_name", "duration_ms", "album_name", "artists"] if c in tracks.columns]
+					if "rank" in show_cols:
+						st.dataframe(tracks[show_cols].set_index("rank"), use_container_width=True)
+					else:
+						st.dataframe(tracks[show_cols], use_container_width=True)
+				else:
+					st.write("No tracks array.")
+
+	# ---------- Unique artists & tracks ----------
+	try:
+		# Unique tracks by track_id
+		unique_tracks = df_recent["track_id"].nunique(dropna=True) if "track_id" in df_recent.columns else 0
+
+		# Unique artists by flattening artist_ids (handles list/str/None)
+		def _to_list(v):
+			if isinstance(v, list):
+				return v
+			if v is None:
+				return []
+			return [v]
+
+		unique_artist_ids = set()
+		if "artist_ids" in df_recent.columns and df_recent["artist_ids"].notna().any():
+			for v in df_recent["artist_ids"].dropna():
+				for a in _to_list(v):
+					unique_artist_ids.add(a)
+		unique_artists = len(unique_artist_ids)
+
+		c1, c2 = st.columns(2)
+		with c1:
+			st.markdown(
+				f"<div style='text-align:center'>"
+				f"<span style='font-size:18px; color:gray'>Unique artists</span><br>"
+				f"<span style='font-size:32px; font-weight:bold'>{unique_artists}</span>"
+				f"</div>",
+				unsafe_allow_html=True,
+			)
+
+		with c2:
+			st.markdown(
+				f"<div style='text-align:center'>"
+				f"<span style='font-size:18px; color:gray'>Unique tracks</span><br>"
+				f"<span style='font-size:32px; font-weight:bold'>{unique_tracks}</span>"
+				f"</div>",
+				unsafe_allow_html=True,
+			)
+	except Exception:
+		st.info("Could not compute unique artists/tracks.")
+

--- a/src/app/tabs/avd_spark.py
+++ b/src/app/tabs/avd_spark.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""
+Thin wrapper that reuses the generic Spark tab but locks it to the owner's base prefix.
+"""
+
+from app.tabs import spark_generic as generic
+
+def render(db, cfg, prefix: str) -> None:
+	# Here, `prefix` is 'avd_spark' (the tab name), but we want to show collections for owner 'avd'.
+	owner_prefix = "avd"	# <-- teammates will copy this file and set their own owner prefix
+	generic.render(db=db, cfg=cfg, prefix=owner_prefix)
+

--- a/src/app/tabs/spark_generic.py
+++ b/src/app/tabs/spark_generic.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+Generic Spark results tab for a teammate's prefix.
+
+This tab discovers all Mongo collections named:
+	<prefix>_spark_*
+
+…and renders each one nicely:
+- top_artists / top_tracks as charts + tables
+- feature_avg grouped tables (with feature name in docs)
+"""
+
+import re
+import streamlit as st
+import pandas as pd
+from pymongo.errors import PyMongoError
+
+def _list_collections(db, prefix: str):
+	pat = re.compile(rf"^{re.escape(prefix)}_spark_")
+	try:
+		return [c for c in db.list_collection_names() if pat.match(c)]
+	except PyMongoError as e:
+		st.error(f"Mongo error while listing collections: {e}")
+		return []
+
+def _load_all(db, coll: str, limit: int = 2000) -> pd.DataFrame:
+	try:
+		cur = db[coll].find({}, {"_id": 0}).sort("batch_ts", -1).limit(limit)
+		return pd.DataFrame(list(cur))
+	except PyMongoError as e:
+		st.error(f"Mongo error while loading {coll}: {e}")
+		return pd.DataFrame()
+
+def _render_top_artists(df: pd.DataFrame):
+	if df.empty:
+		st.info("No data.")
+		return
+	if {"artist_name", "plays"}.issubset(df.columns):
+		st.bar_chart(df.set_index("artist_name")["plays"])
+	st.dataframe(df, use_container_width=True)
+
+def _render_top_tracks(df: pd.DataFrame):
+	if df.empty:
+		st.info("No data.")
+		return
+	cols = [c for c in ["track_name", "track_id", "plays", "batch_ts"] if c in df.columns]
+	if "track_name" in cols and "plays" in cols:
+		st.bar_chart(df.set_index("track_name")["plays"])
+	st.dataframe(df[cols] if cols else df, use_container_width=True)
+
+def _render_feature_avg(df: pd.DataFrame):
+	if df.empty:
+		st.info("No data.")
+		return
+	# Try to guess metric columns
+	metric_cols = [c for c in ["avg_value", "rows"] if c in df.columns]
+	# Display grouped table
+	st.dataframe(df, use_container_width=True)
+	# If there's a single grouping + avg_value -> draw quick bar
+	group_cols = [c for c in df.columns if c not in metric_cols + ["batch_ts", "mode", "feature", "group", "prefix", "batch_id"]]
+	if "avg_value" in df.columns and len(group_cols) == 1:
+		st.bar_chart(df.set_index(group_cols[0])["avg_value"])
+
+def render(db, cfg, prefix: str) -> None:
+	st.caption(f"Spark collections for **{prefix}**")
+	colls = _list_collections(db, prefix)
+	if not colls:
+		st.info(f"No collections found like '{prefix}_spark_*'.")
+		return
+
+	for coll in sorted(colls):
+		st.subheader(coll)
+		df = _load_all(db, coll, limit=2000)
+		mode = "unknown"
+		if "mode" in df.columns and df["mode"].notna().any():
+			mode = df["mode"].iloc[0]
+
+		if mode == "top_artists":
+			_render_top_artists(df)
+		elif mode == "top_tracks":
+			_render_top_tracks(df)
+		elif mode == "feature_avg":
+			st.markdown(f"*Feature:* **{df.get('feature', pd.Series(['?'])).iloc[0]}**  ·  *Group:* **{df.get('group', pd.Series(['?'])).iloc[0]}**")
+			_render_feature_avg(df)
+		else:
+			st.dataframe(df, use_container_width=True)
+

--- a/src/app/team_config.yaml
+++ b/src/app/team_config.yaml
@@ -1,18 +1,12 @@
+ui:
+  tabs_order:
+    - Overview
+    - avd
+    - avd_spark
+
 team:
   - prefix: avd
-    display_name: "Avram Dorin-Emilian"
-  - prefix: gilian
-    display_name: "Rehm Gilian"
-  - prefix: vadim
-    display_name: "Steshkov Vadim"
-  - prefix: alex
-    display_name: "Manzl Alexander"
-  - prefix: raw
-    display_name: Generic RAW
+    display_name: Dorin-Emilian Avram
+  - prefix: avd_spark
+    display_name: AVD · Spark
 
-defaults:
-  mongo_url: "mongodb://root:example@localhost:27017/?authSource=admin"
-  db_name: "spotify_db"
-
-ui:
-  tabs_order: ["Overview", "dorin", "gilian", "vadim", "alex", "Generic RAW"]

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -16,6 +16,33 @@ services:
       retries: 30
       start_period: 10s
     restart: unless-stopped
+    
+  spark-app:
+    build:
+      context: .
+      dockerfile: spark/Dockerfile
+    container_name: spark-app
+    environment:
+      # OVERRIDE endpoints for inside-container networking
+      KAFKA_BOOTSTRAP: "kafka:19092"
+      MONGO_URL: "mongodb://root:example@mongo:27017/?authSource=admin"
+
+      # restul pot rămâne ca la tine:
+      KAFKA_TOPICS: "${KAFKA_TOPICS}"
+      MONGO_DB: "${MONGO_DB}"
+      APP_PREFIX: "${APP_PREFIX}"
+      SPARK_PACKAGES: "${SPARK_PACKAGES}"
+    depends_on:
+      - kafka
+      - mongo
+    volumes:
+      - ./:/app
+    command: >
+      bash -lc "
+      python3 -m pip install -r spark/requirements.txt &&
+      PYSPARK_SUBMIT_ARGS='--packages ${SPARK_PACKAGES} pyspark-shell' python3 -m spark.streaming_job
+      "
+
 
   kafka:
     image: confluentinc/cp-kafka:7.5.0
@@ -65,4 +92,5 @@ services:
 
 volumes:
   mongo_data:
+
 

--- a/src/makefile
+++ b/src/makefile
@@ -1,49 +1,50 @@
-# ===========
-# Variables
-# ===========
+# ======================================================
+# Generic Makefile (tabs only) — comments in English
+# Supports:
+#   - Host mode: producer/consumer/streamlit using localhost
+#   - Docker mode: ephemeral python containers on Docker network
+#   - Spark Structured Streaming container (docker-compose service)
+# ======================================================
+
+# ----------------
+# Python / paths
+# ----------------
 PY := .venv/bin/python3
 
-# Containers in docker-compose.yml
+# Environment presets
+ENV_HOST  := envs/.env.host     # host: KAFKA_BOOTSTRAP=localhost:9092, MONGO_URL=...localhost...
+ENV_SPARK := envs/.env.spark    # docker: KAFKA_BOOTSTRAP=kafka:19092, MONGO_URL=...mongo...
+
+# Docker container names (see docker-compose.yml)
 KAFKA_CONTAINER ?= kafka
 MONGO_CONTAINER ?= mongo
 
-# Kafka brokers
-BROKER_INTERNAL ?= kafka:19092    # used from inside containers (docker exec)
-BROKER_EXTERNAL ?= localhost:9092 # used from host tools
+# Kafka brokers (reference)
+BROKER_INTERNAL ?= kafka:19092     # used inside Docker network
+BROKER_EXTERNAL ?= localhost:9092  # used from host tools
 
-# AVD Kafka topics (Dorin) — kept for backward compatibility
-TOPIC_EVENTS ?= avd_recent_events
-TOPIC_TOP10  ?= avd_artist_market_top_tracks
-
-# Default Spark packages (can be overridden via environment/.env)
+# Spark extra packages
 export SPARK_PACKAGES ?= org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1,org.apache.kafka:kafka-clients:3.5.2
 
-# Allow 'python -m' imports from current folder
+# Allow "python -m" imports from project root
 export PYTHONPATH := $(shell pwd)
 
-# ===========
-# Phony
-# ===========
-.PHONY: up down logs \
-	kafka-wait kafka-init kafka-init-from-env kafka-list \
-	kafka-tail kafka-tail-topic kafka-event kafka-event-topic \
-	kafka-delete-avd kafka-delete-topic \
-	run-avd run-% consume app \
-	env-avd env-alex env-vadim \
-	spark-run
+# ----------------
+# PHONY targets
+# ----------------
+.PHONY: \
+	up down logs \
+	env-host env-spark show-env \
+	kafka-wait kafka-init-from-env kafka-list kafka-tail-topic kafka-event-topic kafka-delete-topic \
+	run run-host run-avd run-docker \
+	consume-host consume-docker \
+	app-host app-docker \
+	spark-build spark-up spark-logs spark-down spark-run-local
 
-# ===========
-# Spark (Structured Streaming)
-# ===========
-spark-run:
-	$(PY) -m pip install -r spark/requirements.txt
-	PYSPARK_SUBMIT_ARGS="--packages $(SPARK_PACKAGES) pyspark-shell" \
-	$(PY) -m spark.streaming_job
+# ======================================================
+# Docker stack (Kafka, Mongo, Spark service)
+# ======================================================
 
-
-# ===========
-# Docker stack
-# ===========
 up:
 	docker compose up -d
 
@@ -53,9 +54,29 @@ down:
 logs:
 	docker compose logs -f
 
-# ===========
-# Kafka helpers (readiness)
-# ===========
+# ======================================================
+# Environment helpers
+# ======================================================
+
+env-host:
+	@if [ ! -f $(ENV_HOST) ]; then echo "Missing $(ENV_HOST)"; exit 1; fi
+	@cp $(ENV_HOST) .env
+	@echo "Loaded host environment -> .env"
+
+env-spark:
+	@if [ ! -f $(ENV_SPARK) ]; then echo "Missing $(ENV_SPARK)"; exit 1; fi
+	@cp $(ENV_SPARK) .env
+	@echo "Loaded spark/docker environment -> .env"
+
+show-env:
+	@echo "Active .env (key vars):"
+	@grep -E '^(APP_PREFIX|KAFKA_BOOTSTRAP|MONGO_URL|KAFKA_TOPICS|SPARK_MODE|SPARK_FEATURE|SPARK_GROUP)=' .env || true
+
+# ======================================================
+# Kafka utilities
+# ======================================================
+
+# Wait for Kafka to accept commands
 kafka-wait:
 	@echo "[WAIT] Waiting for Kafka to be ready..."
 	@docker exec -it $(KAFKA_CONTAINER) bash -lc '\
@@ -67,20 +88,10 @@ kafka-wait:
 	echo "ERROR: Kafka not ready in time." >&2; \
 	exit 1'
 
-# ===========
-# Topic management
-# ===========
-# AVD: create Dorin's topics (idempotent)
-kafka-init: kafka-wait
-	docker exec -it $(KAFKA_CONTAINER) kafka-topics --create --if-not-exists --topic $(TOPIC_EVENTS) --bootstrap-server $(BROKER_INTERNAL) --partitions 1 --replication-factor 1
-	docker exec -it $(KAFKA_CONTAINER) kafka-topics --create --if-not-exists --topic $(TOPIC_TOP10)  --bootstrap-server $(BROKER_INTERNAL) --partitions 1 --replication-factor 1
-
-# Generic: create topics listed in KAFKA_TOPICS from current .env
+# Create topics from KAFKA_TOPICS in .env (idempotent)
 kafka-init-from-env: kafka-wait
 	@bash -lc 'set -a; [ -f .env ] && . .env; \
-	if [ -z "$$KAFKA_TOPICS" ]; then \
-		echo "No KAFKA_TOPICS in .env. Skipping."; exit 0; \
-	fi; \
+	if [ -z "$$KAFKA_TOPICS" ]; then echo "No KAFKA_TOPICS found. Skipping."; exit 0; fi; \
 	for t in $${KAFKA_TOPICS//,/ }; do \
 		echo "Creating topic: $$t"; \
 		docker exec -it $(KAFKA_CONTAINER) kafka-topics --create --if-not-exists --topic $$t --bootstrap-server $(BROKER_INTERNAL) --partitions 1 --replication-factor 1; \
@@ -90,73 +101,143 @@ kafka-init-from-env: kafka-wait
 kafka-list:
 	docker exec -it $(KAFKA_CONTAINER) kafka-topics --list --bootstrap-server $(BROKER_INTERNAL)
 
-# Tail AVD events from beginning
-kafka-tail:
-	docker exec -it $(KAFKA_CONTAINER) kafka-console-consumer --bootstrap-server $(BROKER_INTERNAL) --topic $(TOPIC_EVENTS) --from-beginning --property print.key=true --property print.value=true
-
-# Tail an arbitrary topic: make kafka-tail-topic TOPIC=alex_events
+# Tail a topic from beginning (Usage: make kafka-tail-topic TOPIC=name)
 kafka-tail-topic:
 	@if [ -z "$(TOPIC)" ]; then echo "Usage: make kafka-tail-topic TOPIC=<name>"; exit 1; fi
 	docker exec -it $(KAFKA_CONTAINER) kafka-console-consumer --bootstrap-server $(BROKER_INTERNAL) --topic $(TOPIC) --from-beginning --property print.key=true --property print.value=true
 
-# Produce a one-off JSON line to AVD events (paste one line, Ctrl+D to end)
-kafka-event:
-	@echo '# Paste ONE line of JSON, then Ctrl+D'
-	docker exec -i $(KAFKA_CONTAINER) kafka-console-producer --bootstrap-server $(BROKER_INTERNAL) --topic $(TOPIC_EVENTS)
-
-# Produce a one-off JSON line to arbitrary topic: make kafka-event-topic TOPIC=alex_events
+# Produce one JSON line to a topic (Usage: make kafka-event-topic TOPIC=name)
 kafka-event-topic:
 	@if [ -z "$(TOPIC)" ]; then echo "Usage: make kafka-event-topic TOPIC=<name>"; exit 1; fi
 	@echo '# Paste ONE line of JSON, then Ctrl+D'
 	docker exec -i $(KAFKA_CONTAINER) kafka-console-producer --bootstrap-server $(BROKER_INTERNAL) --topic $(TOPIC)
 
-# Delete AVD topics (careful!)
-kafka-delete-avd:
-	docker exec -it $(KAFKA_CONTAINER) kafka-topics --delete --topic $(TOPIC_EVENTS) --bootstrap-server $(BROKER_INTERNAL) || true
-	docker exec -it $(KAFKA_CONTAINER) kafka-topics --delete --topic $(TOPIC_TOP10)  --bootstrap-server $(BROKER_INTERNAL) || true
-
-# Delete arbitrary topic: make kafka-delete-topic TOPIC=alex_events
+# Delete a topic (Usage: make kafka-delete-topic TOPIC=name)
 kafka-delete-topic:
 	@if [ -z "$(TOPIC)" ]; then echo "Usage: make kafka-delete-topic TOPIC=<name>"; exit 1; fi
 	docker exec -it $(KAFKA_CONTAINER) kafka-topics --delete --topic $(TOPIC) --bootstrap-server $(BROKER_INTERNAL) || true
 
-# ===========
-# Python apps
-# ===========
-# Dorin (AVD) end-to-end: stack up, create AVD topics, run producer
-run-avd: up kafka-init-from-env
+# ======================================================
+# HOST MODE (your default workflow on laptop)
+# ======================================================
+
+# Alias: "make run" should run Dorin's AVD producer on host
+run: run-avd
+
+# Run AVD producer on host (uses envs/.env.host)
+run-host run-avd: env-host up kafka-init-from-env
 	$(PY) -m producers.avd_producer
 
-# Generic: run teammate by prefix (expects envs/.env.<prefix> that sets PRODUCER_ENTRY + KAFKA_TOPICS)
-# Example: make run-alex  -> copies envs/.env.alex to .env, creates topics from KAFKA_TOPICS, runs PRODUCER_ENTRY
-run-%: env-% up kafka-init-from-env
-	@bash -lc 'set -a; . .env; \
-	if [ -z "$$PRODUCER_ENTRY" ]; then \
-		echo "ERROR: PRODUCER_ENTRY not set in .env.$*"; exit 1; \
-	fi; \
-	echo "Running producer: $$PRODUCER_ENTRY"; \
-	$(PY) $$PRODUCER_ENTRY'
-
-# Start the Mongo writer (Kafka consumer)
-consume:
+# Run Mongo writer (consumer) on host
+consume-host: env-host up
 	$(PY) -m consumers.kafka_consumer
 
-# Streamlit app (runs from src/)
-app:
+# Run Streamlit dashboard on host
+app-host: env-host up
 	$(PY) -m streamlit run app/streamlit_app.py
 
-# ===========
-# Env shortcuts
-# ===========
-env-avd:
-	cp envs/.env.avd .env
-	@echo "Loaded env: envs/.env.avd -> .env"
+# ======================================================
+# DOCKER MODE (no localhost assumptions)
+# ======================================================
 
-env-alex:
-	cp envs/.env.alex .env
-	@echo "Loaded env: envs/.env.alex -> .env"
+# Run producer in a temporary Python container on Docker network
+run-docker: up
+	docker run --rm -it \
+		--network src_default \
+		--env-file $(ENV_SPARK) \
+		-v $(PWD):/app -w /app \
+		python:3.11-slim bash -lc "\
+			apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+			pip install --no-cache-dir spotipy pymongo confluent-kafka python-dotenv && \
+			python3 -m producers.avd_producer \
+		"
 
-env-vadim:
-	cp envs/.env.vadim .env
-	@echo "Loaded env: envs/.env.vadim -> .env"
+# Run consumer in a temporary Python container on Docker network
+consume-docker: up
+	docker run --rm -it \
+		--network src_default \
+		--env-file $(ENV_SPARK) \
+		-v $(PWD):/app -w /app \
+		python:3.11-slim bash -lc "\
+			pip install --no-cache-dir pymongo confluent-kafka python-dotenv && \
+			python3 -m consumers.kafka_consumer \
+		"
+
+# Run Streamlit from a throwaway Python container (no local Python needed)
+# - Installs minimal deps (includes PyYAML for team_config.yaml)
+# - Binds current folder into /app
+# - Exposes PORT on the host (default 8501)
+PORT ?= 8501
+
+app-docker:
+	docker compose up -d
+	docker run --rm -it \
+		--network src_default \
+		--env-file envs/.env.spark \
+		-p $(PORT):8501 \
+		-v "$(shell pwd)":/app -w /app \
+		python:3.11-slim bash -lc "\
+			pip install --no-cache-dir streamlit pymongo python-dotenv pyyaml && \
+			python3 -m streamlit run app/streamlit_app.py \
+				--server.headless=true \
+				--server.address=0.0.0.0 \
+				--server.port=8501 \
+				--browser.gatherUsageStats=false"
+
+# Tail logs from the ephemeral app-docker run (if you wrap it into 'docker compose run', keep this)
+app-docker-logs:
+	docker logs -f $$(docker ps -q --filter "ancestor=python:3.11-slim") || true
+
+# Free the port in case a stray container or process still owns it
+app-docker-kill-port:
+	-@lsof -ti :$(PORT) | xargs -r kill -9
+	
+# ======================================================
+# SPARK (Structured Streaming) — docker-compose service
+# ======================================================
+
+# Build the Spark image
+spark-build:
+	docker compose build spark-app
+
+# Start Spark service with envs/.env.spark (uses kafka:19092, mongo:27017)
+spark-up:
+	docker compose --env-file $(ENV_SPARK) up -d spark-app
+
+# Stream Spark logs
+spark-logs:
+	docker compose logs -f spark-app
+
+# Remove Spark service container
+spark-down:
+	docker compose rm -sf spark-app
+
+# ======================================================
+# SPARK local (debug only)
+# ======================================================
+
+spark-run-local:
+	$(PY) -m pip install -r spark/requirements.txt
+	PYSPARK_SUBMIT_ARGS="--packages $(SPARK_PACKAGES) pyspark-shell" \
+	$(PY) -m spark.streaming_job
+	
+# ============================
+# Environment quick test
+# ============================
+# Displays key environment variables loaded from .env
+# Useful for verifying Docker vs Local configurations
+.PHONY: test-env
+test-env:
+	@echo ""
+	@echo "  Environment check:"
+	@echo "----------------------------"
+	@bash -lc 'set -a; [ -f .env ] && . .env; \
+		echo "APP_PREFIX       = $$APP_PREFIX"; \
+		echo "KAFKA_BOOTSTRAP  = $$KAFKA_BOOTSTRAP"; \
+		echo "MONGO_URL        = $$MONGO_URL"; \
+		echo "SPARK_MODE       = $$SPARK_MODE"; \
+		echo "PRODUCER_ENTRY   = $$PRODUCER_ENTRY"; \
+		echo "----------------------------"; \
+		echo " Environment loaded successfully."'
+
 

--- a/src/producers/avd_producer.py
+++ b/src/producers/avd_producer.py
@@ -33,7 +33,7 @@ from lib.kafka_producer import KafkaJsonProducer
 
 # ================== ENV / CONFIG ==================
 # Load .env from the current working dir
-load_dotenv(dotenv_path=".env", override=True)
+load_dotenv(dotenv_path=".env", override=False) #do not override env that already comes from Docker
 
 def _env_any(*keys: str, required: bool = False, default: Optional[str] = None) -> Optional[str]:
 	"""Return first non-empty env var among keys."""

--- a/src/spark/Dockerfile
+++ b/src/spark/Dockerfile
@@ -1,0 +1,27 @@
+# Minimal Python + Java base; PySpark ships Spark itself
+FROM python:3.11-slim
+
+# Install Java (required by Spark)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-21-jre-headless curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Workdir inside container
+WORKDIR /app
+
+# Copy requirements first (better cache)
+COPY spark/requirements.txt /app/spark/requirements.txt
+
+# Install Python deps
+RUN pip install --no-cache-dir -r /app/spark/requirements.txt
+
+# Copy the whole src (code, including spark/streaming_job.py)
+COPY . /app
+
+# Default env (can be overridden by docker-compose or `docker run -e`)
+ENV PYTHONUNBUFFERED=1
+
+# Default command: run Spark job
+# (packages are provided via env SPARK_PACKAGES if needed)
+CMD [ "python", "-m", "spark.streaming_job" ]
+

--- a/src/spark/streaming_job.py
+++ b/src/spark/streaming_job.py
@@ -2,44 +2,57 @@
 # -*- coding: utf-8 -*-
 
 """
-Spark Structured Streaming job:
-	- Consumes JSON events from Kafka topics (from .env KAFKA_TOPICS / KAFKA_BOOTSTRAP)
-	- Parses flexible schema (handles artist_names as str|array|null, best-effort)
-	- Computes Top Artists by play count per micro-batch
-	- Writes aggregate to MongoDB (collection: <APP_PREFIX>_spark_leaderboard)
-	- Also prints aggregates to console for live demo
+Generic Spark Structured Streaming job.
 
-Notes:
-	- No Mongo Spark connector needed; we use foreachBatch + PyMongo (simpler & portable)
-	- Safe on mixed/historic schemas; unknown fields are ignored
+- Reads JSON events from Kafka (topics provided via env: SPARK_KAFKA_TOPICS or KAFKA_TOPICS).
+- Supports multiple aggregation "modes" (env SPARK_MODE):
+	* top_artists  -> Top-N by artist_names
+	* top_tracks   -> Top-N by track_name
+	* feature_avg  -> Average of a numeric field (SPARK_FEATURE), grouped by SPARK_GROUP
+- Writes results to MongoDB collection: <APP_PREFIX>_spark_<mode>
+- Prints aggregates to console for live demo.
+
+Design goals:
+- Portable (no Mongo Spark connector; uses foreachBatch + PyMongo).
+- Robust to mixed schemas sent by teammates (fields can be null/string/JSON-array).
+- No hardcoded topics/fields in code; everything configurable from .env.
 """
 
 import os
 from typing import List
 
 from dotenv import load_dotenv
-
 from pyspark.sql import SparkSession, DataFrame
 from pyspark.sql import functions as F
 from pyspark.sql.types import (
-	StructType, StructField, StringType, LongType, ArrayType
+	StructType, StructField, StringType, LongType, ArrayType, DoubleType
 )
 
 # ---------------------------
 # Load environment variables
 # ---------------------------
-load_dotenv()  # loads .env if present
+load_dotenv()
 
-APP_PREFIX = os.getenv("APP_PREFIX", "avd").strip()
-KAFKA_BOOTSTRAP = os.getenv("KAFKA_BOOTSTRAP", "localhost:9092")
-KAFKA_TOPICS = os.getenv("KAFKA_TOPICS", "avd_recent_events")
+APP_PREFIX = os.getenv("APP_PREFIX", "demo").strip()
 
-MONGO_URL = os.getenv("MONGO_URL", "mongodb://root:example@localhost:27017/?authSource=admin")
-MONGO_DB = os.getenv("MONGO_DB", "spotify_db")
-OUT_COLL = f"{APP_PREFIX}_spark_leaderboard"  # e.g., avd_spark_leaderboard
+# Topic selection priority: SPARK_KAFKA_TOPICS (if set) else KAFKA_TOPICS
+SPARK_KAFKA_TOPICS = os.getenv("SPARK_KAFKA_TOPICS", "").strip()
+KAFKA_TOPICS = SPARK_KAFKA_TOPICS or os.getenv("KAFKA_TOPICS", "events").strip()
 
-# You can override this from the Makefile via PYSPARK_SUBMIT_ARGS,
-# but also inject it here so the job works when launched directly.
+# Kafka & mode configuration
+KAFKA_BOOTSTRAP = os.getenv("KAFKA_BOOTSTRAP", "localhost:9092").strip()
+SPARK_MODE = os.getenv("SPARK_MODE", "top_artists").strip()  # top_artists | top_tracks | feature_avg
+
+# Feature mode only
+SPARK_FEATURE = os.getenv("SPARK_FEATURE", "track_duration_ms").strip()
+SPARK_GROUP = os.getenv("SPARK_GROUP", "market_used").strip()  # comma-separated grouping cols
+
+# Mongo config
+MONGO_URL = os.getenv("MONGO_URL", "mongodb://root:example@localhost:27017/?authSource=admin").strip()
+MONGO_DB = os.getenv("MONGO_DB", "spotify_db").strip()
+OUT_COLL = f"{APP_PREFIX}_spark_{SPARK_MODE}"
+
+# Packages (Kafka source). Can be overridden from env.
 SPARK_PACKAGES = os.getenv(
 	"SPARK_PACKAGES",
 	"org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1,org.apache.kafka:kafka-clients:3.5.2",
@@ -47,18 +60,20 @@ SPARK_PACKAGES = os.getenv(
 
 print(f"[Spark] bootstrap: {KAFKA_BOOTSTRAP}")
 print(f"[Spark] topics: {KAFKA_TOPICS.split(',')}")
+print(f"[Spark] mode: {SPARK_MODE}")
+if SPARK_MODE == "feature_avg":
+	print(f"[Spark] feature: {SPARK_FEATURE} | group: {SPARK_GROUP}")
 
 # ---------------------------
 # Spark session
 # ---------------------------
 spark = (
 	SparkSession.builder
-		.appName(f"{APP_PREFIX}_kafka_to_mongo_leaderboard")
+		.appName(f"{APP_PREFIX}_kafka_to_mongo_{SPARK_MODE}")
 		.config("spark.sql.shuffle.partitions", "2")
-		.config("spark.jars.packages", SPARK_PACKAGES)  # <-- important
+		.config("spark.jars.packages", SPARK_PACKAGES)
 		.getOrCreate()
 )
-# Lower Spark console noise; switch to "INFO" for debugging
 spark.sparkContext.setLogLevel("WARN")
 
 # ---------------------------
@@ -68,86 +83,160 @@ df_raw = (
 	spark.readStream
 		.format("kafka")
 		.option("kafka.bootstrap.servers", KAFKA_BOOTSTRAP)
-		.option("subscribe", KAFKA_TOPICS)  # comma-separated topics supported
+		.option("subscribe", KAFKA_TOPICS)  # comma-separated list supported
 		.option("startingOffsets", "latest")
 		.load()
 )
 
-# Kafka value is binary; cast to string
 df_json_str = df_raw.select(
 	F.col("timestamp").alias("kafka_ts"),
 	F.col("value").cast("string").alias("raw_json")
 )
 
 # ---------------------------
-# Flexible schema for events
+# Base schema (keep fields generic & safe)
+# - artist_* as StringType since producers may send string OR JSON-array.
+# - We normalize after parsing (see normalizers below).
 # ---------------------------
 event_schema = StructType([
 	StructField("user_id", StringType(), True),
 	StructField("track_id", StringType(), True),
 	StructField("track_name", StringType(), True),
-	StructField("artist_ids", ArrayType(StringType()), True),   # may be list in newer docs
-	StructField("artist_names", ArrayType(StringType()), True), # may be list OR string in older docs
+	StructField("artist_ids", StringType(), True),		# may be '["a","b"]' or "a"
+	StructField("artist_names", StringType(), True),	# may be '["A","B"]' or "A"
 	StructField("album_name", StringType(), True),
 	StructField("market_used", StringType(), True),
 	StructField("played_at", StringType(), True),
 	StructField("track_duration_ms", LongType(), True),
+
+	# Optional feature-style fields colleagues might send (keep them as strings; we cast later)
+	StructField("danceability", StringType(), True),
+	StructField("energy", StringType(), True),
+	StructField("valence", StringType(), True),
 ])
 
-# Parse JSON with PERMISSIVE mode (malformed -> null)
 df_parsed = df_json_str.select(
 	F.from_json(F.col("raw_json"), event_schema, {"mode": "PERMISSIVE"}).alias("d"),
-	"kafka_ts",
-	"raw_json"
-).select("kafka_ts", "raw_json", "d.*")
+	"kafka_ts"
+).select("kafka_ts", "d.*")
 
 # ---------------------------
-# Robust normalization of artist_names:
-#	- if array<string> -> keep
-#	- if null but raw_json has a string at $.artist_names -> wrap as array
-#	- else -> empty array
+# Helpers: robust normalizers
 # ---------------------------
-# Best-effort fallback: pull raw field as string (when producers sent a scalar)
-raw_artist_names_str = F.get_json_object(F.col("raw_json"), "$.artist_names")
+def normalize_array_like(col: F.Column) -> F.Column:
+	"""
+	Normalize a column that can be:
+	- null
+	- plain string "A"
+	- comma-separated "A,B"
+	- JSON array '["A","B"]'
+	Returns array<string>.
+	"""
+	# If it's a JSON array string, parse it as array<string>
+	json_arr = F.from_json(col, ArrayType(StringType()))
+	return (
+		F.when(col.isNull(), F.array().cast("array<string>"))
+		 .when(col.startswith("["), json_arr)
+		 .when(F.instr(col, ",") > 0, F.split(col, r"\s*,\s*"))
+		 .otherwise(F.array(col.cast("string")))
+	)
 
+def ensure_columns(df: DataFrame, names: List[str]) -> DataFrame:
+	"""
+	Make sure all column names exist in df.
+	If missing, add them as NULL columns so downstream groupBy/select won't crash.
+	"""
+	for n in names:
+		if n and n not in df.columns:
+			df = df.withColumn(n, F.lit(None).cast(StringType()))
+	return df
+
+# Normalize the artist fields we actually aggregate on for top_artists
 df_norm = (
 	df_parsed
-		.withColumn(
-			"artist_names_norm",
-			F.when(F.col("artist_names").isNotNull(), F.col("artist_names"))
-			 .when(raw_artist_names_str.isNotNull(), F.array(raw_artist_names_str.cast("string")))
-			 .otherwise(F.array().cast("array<string>"))
+		.withColumn("artist_names_norm", normalize_array_like(F.col("artist_names")))
+		.withColumn("artist_ids_norm", normalize_array_like(F.col("artist_ids")))
+)
+
+# ---------------------------
+# Aggregation builders (modes)
+# ---------------------------
+def build_top_artists(df: DataFrame) -> DataFrame:
+	"""
+	Explode artist_names and compute Top 10 by play count.
+	"""
+	df_exploded = df.select(F.explode("artist_names_norm").alias("artist_name"))
+	return (
+		df_exploded
+			.groupBy("artist_name")
+			.agg(F.count(F.lit(1)).alias("plays"))
+			.orderBy(F.col("plays").desc())
+			.limit(10)
+			.withColumn("batch_ts", F.current_timestamp())
+			.select("batch_ts", "artist_name", "plays")
+	)
+
+def build_top_tracks(df: DataFrame) -> DataFrame:
+	"""
+	Compute Top 10 tracks by play count.
+	"""
+	df_src = ensure_columns(df, ["track_id", "track_name"])
+	return (
+		df_src.groupBy("track_id", "track_name")
+			.agg(F.count(F.lit(1)).alias("plays"))
+			.orderBy(F.col("plays").desc())
+			.limit(10)
+			.withColumn("batch_ts", F.current_timestamp())
+			.select("batch_ts", "track_id", "track_name", "plays")
+	)
+
+def build_feature_avg(df: DataFrame, feat: str, group_expr: str) -> DataFrame:
+	"""
+	Average any numeric feature by chosen grouping columns.
+	- feat: column name inside df (string). It will be cast to DOUBLE.
+	- group_expr: comma-separated list of columns to group by. Missing cols are added as NULL.
+	"""
+	cols = [c.strip() for c in group_expr.split(",") if c.strip()]
+	df_src = ensure_columns(df, cols + [feat])
+
+	# Cast feature to double; filter out rows where cast fails (NULL)
+	df_feat = df_src.withColumn(feat, F.col(feat).cast(DoubleType())).where(F.col(feat).isNotNull())
+
+	if cols:
+		out = (
+			df_feat.groupBy(*[F.col(c) for c in cols])
+				.agg(F.avg(F.col(feat)).alias("avg_value"), F.count(F.lit(1)).alias("rows"))
+				.orderBy(F.col("avg_value").desc())
+				.withColumn("batch_ts", F.current_timestamp())
 		)
-)
+		return out.select(*cols, "avg_value", "rows", "batch_ts")
+	else:
+		out = (
+			df_feat.agg(F.avg(F.col(feat)).alias("avg_value"), F.count(F.lit(1)).alias("rows"))
+				.withColumn("batch_ts", F.current_timestamp())
+		)
+		return out.select("avg_value", "rows", "batch_ts")
+
+# Choose mode
+if SPARK_MODE == "top_tracks":
+	df_out = build_top_tracks(df_norm)
+elif SPARK_MODE == "feature_avg":
+	df_out = build_feature_avg(df_norm, SPARK_FEATURE, SPARK_GROUP)
+else:
+	df_out = build_top_artists(df_norm)  # default
 
 # ---------------------------
-# Aggregation (Top Artists by plays) per micro-batch
-# ---------------------------
-df_exploded = df_norm.select(F.explode("artist_names_norm").alias("artist_name"))
-
-df_top = (
-	df_exploded
-		.groupBy("artist_name")
-		.agg(F.count(F.lit(1)).alias("plays"))
-		.orderBy(F.col("plays").desc())
-		.limit(10)
-		.withColumn("batch_ts", F.current_timestamp())
-		.select("batch_ts", "artist_name", "plays")
-)
-
-# ---------------------------
-# Mongo sink via foreachBatch (PyMongo)
+# Mongo sink via foreachBatch
 # ---------------------------
 def write_batch_to_mongo(batch_df: DataFrame, batch_id: int) -> None:
 	"""
-	Called for every micro-batch.
-	Writes the Top-10 rows to MongoDB as documents:
-	{ batch_ts, artist_name, plays, batch_id, prefix }
+	For each micro-batch, insert result rows into MongoDB as documents.
+	Extra fields are added for traceability.
 	"""
 	import pymongo
 	from pymongo import MongoClient
 
-	rows: List[dict] = [row.asDict(recursive=True) for row in batch_df.collect()]
+	rows = [r.asDict(recursive=True) for r in batch_df.collect()]
 	if not rows:
 		return
 
@@ -157,6 +246,10 @@ def write_batch_to_mongo(batch_df: DataFrame, batch_id: int) -> None:
 		for r in rows:
 			r["batch_id"] = batch_id
 			r["prefix"] = APP_PREFIX
+			r["mode"] = SPARK_MODE
+			if SPARK_MODE == "feature_avg":
+				r["feature"] = SPARK_FEATURE
+				r["group"] = SPARK_GROUP
 		coll.insert_many(rows, ordered=False)
 	finally:
 		client.close()
@@ -165,23 +258,22 @@ def write_batch_to_mongo(batch_df: DataFrame, batch_id: int) -> None:
 # Dual sink: console + Mongo
 # ---------------------------
 query_console = (
-	df_top.writeStream
-		.outputMode("complete")  # print whole Top-10 each time
+	df_out.writeStream
+		.outputMode("complete")
 		.format("console")
 		.option("truncate", "false")
-		.option("numRows", "20")
+		.option("numRows", "50")
 		.start()
 )
 
 query_mongo = (
-	df_top.writeStream
+	df_out.writeStream
 		.outputMode("complete")
 		.foreachBatch(write_batch_to_mongo)
-		.option("checkpointLocation", f"/tmp/{APP_PREFIX}_spark_leaderboard_ck")
+		.option("checkpointLocation", f"/tmp/{APP_PREFIX}_spark_{SPARK_MODE}_ck")
 		.start()
 )
 
-# Wait for both streams
 query_console.awaitTermination()
 query_mongo.awaitTermination()
 


### PR DESCRIPTION
Overview:
- Split AVD tab: moved legacy dashboard into app/tabs/avd_classic.py and made app/tabs/avd.py a thin orchestrator with two sub-tabs (Classic + Spark).
- Added generic Spark tab (app/tabs/spark_generic.py) to auto-discover and render <prefix>_spark_* collections.

Spark:
- Rewrote spark/streaming_job.py as a generic job with modes:
  * top_artists (default), top_tracks, feature_avg.
- Robust normalization for artist fields and feature casting.
- Mongo sink via foreachBatch with richer metadata (prefix/mode/feature/group).
- New image + service: spark/Dockerfile and docker-compose service "spark-app".

App:
- team_config.yaml: added explicit tab order (Overview, avd, avd_spark) and labeled the AVD Spark tab.

Tooling:
- makefile: big cleanup and new targets for host vs docker workflows: run/run-avd, run-docker, consume-host/consume-docker, app-host/app-docker, spark-build/up/logs/down, env-host/env-spark, show-env, test-env.
- Producers now respect container envs (dotenv override disabled in Docker).

Compose:
- docker-compose.yml: added spark-app service with correct in-network endpoints.

Notes:
- Keep .env files out of git; use envs/.env.host și envs/.env.spark pentru preseturi.